### PR TITLE
Use gdmc to resolve buildscript classpath deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,3 @@
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.episode6.hackit.deployable:deployable:0.2.1'
-    classpath 'com.episode6.hackit.gdmc:gdmc:0.1.10'
-    classpath 'me.tatarka:gradle-retrolambda:3.7.0'
-  }
-}
-
 wrapper {
   gradleVersion = "4.9"
   distributionType = "all"

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+// some buildscript dependencies fail to resolve without this
+// actual buildscript dependencies are defined in buildSrc/build.gradle
+buildscript { repositories { jcenter() } }
+
 wrapper {
   gradleVersion = "4.9"
   distributionType = "all"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.episode6.hackit.gdmc:gdmc:0.1.10'
+  }
+}
+
+repositories {
+    jcenter()
+}
+
+apply plugin: 'groovy'
+apply plugin: 'com.episode6.hackit.gdmc'
+
+dependencies {
+  runtimeClasspath 'com.episode6.hackit.gdmc:gdmc'
+  runtimeClasspath 'com.episode6.hackit.deployable:deployable'
+  runtimeClasspath 'me.tatarka:gradle-retrolambda'
+}

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,1 @@
+gdmc.file=../gdmc/gdmc.json


### PR DESCRIPTION
Move buildscript classpath dependencies to buildSrc's runtimeClasspath so that all versions may be resolved via gdmc