### PR TITLE
Add new method to inject existing objects with a TypeToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ### v0.0.16-SNAPSHOT - unreleased
+ - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.
 
 ### v0.0.15 - March 12th, 2019
  - Replaced old `TypeToken` implementation with guava's by way of https://github.com/episode6/mockspresso-reflect-guava. Adds about 1MB of bloat to the overall build, but now mockspresso doesn't fall over when parsing TypeVariable parameter.

--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
@@ -33,9 +33,24 @@ public interface Mockspresso {
    * Inject an existing object with mockspresso dependencies.
    * Field and method injection will be performed (assuming the
    * injector of this mockspresso instance supports it)
-   * @param instance The object to be injected.
+   * @param instance The object to inject mocks/dependencies into.
    */
   void inject(Object instance);
+
+  /**
+   * An alternative signature to {@link #inject(Object)}. Use this
+   * method and pass an explic type token if injecting a pre-
+   * constructed generic object that injects parameters defined as
+   * TypeVariables. I.e.
+   * {@code class MySampleGeneric<V> { @Inject V myInjectedVariable; } }
+   * Without the typeToken represented the object being injected, we're
+   * unable to infer the correct type for the generic paremeter, and may
+   * wind up providing a mock {@link Object} instead of the correct mapping.
+   * @param instance The object to inject mocks/dependencies into.
+   * @param typeToken A TypeToken representing the complete type of instance
+   * @param <T> The Type of instance param
+   */
+  <T> void inject(T instance, TypeToken<T> typeToken);
 
   /**
    * Get a dependency (creating a new mock, if needed) from mockspresso.

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
@@ -67,6 +67,11 @@ abstract class AbstractDelayedMockspresso implements Mockspresso, MockspressoInt
   }
 
   @Override
+  public <T> void inject(T instance, TypeToken<T> typeToken) {
+    getDelegate().inject(instance, typeToken);
+  }
+
+  @Override
   public <T> T getDependency(DependencyKey<T> key) {
     return getDelegate().getDependency(key);
   }

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoImpl.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoImpl.java
@@ -44,12 +44,21 @@ class MockspressoImpl implements Mockspresso, MockspressoInternal {
 
   @Override
   public void inject(Object instance) {
-    DependencyKey<?> key = DependencyKey.of(instance.getClass());
+    injectInternal(instance, TypeToken.of(instance.getClass()));
+  }
+
+  @Override
+  public <T> void inject(T instance, TypeToken<T> typeToken) {
+    injectInternal(instance, typeToken);
+  }
+
+  private void injectInternal(Object instance, TypeToken<?> typeToken) {
+    DependencyKey<?> key = DependencyKey.of(typeToken);
     DependencyProvider dependencyProvider = mDependencyProviderFactory.getDependencyProviderFor(key);
     mRealObjectMaker.injectObject(
         dependencyProvider,
         instance,
-        key.typeToken);
+        typeToken);
   }
 
   @Override

--- a/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
+++ b/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
@@ -64,6 +64,11 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
   }
 
   @Override
+  public <T> void inject(T instance, TypeToken<T> typeToken) {
+    mDelegate.inject(instance, typeToken);
+  }
+
+  @Override
   public <T> T getDependency(DependencyKey<T> key) {
     return mDelegate.getDependency(key);
   }
@@ -105,6 +110,11 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
     @Override
     public void inject(Object instance) {
       mDelegate.inject(instance);
+    }
+
+    @Override
+    public <T> void inject(T instance, TypeToken<T> typeToken) {
+      mDelegate.inject(instance, typeToken);
     }
 
     @Override

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/GenericConstructorTest.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/GenericConstructorTest.java
@@ -111,7 +111,7 @@ public class GenericConstructorTest {
         .injector().javax()
         .dependency(TestObject.class, testMock)
         .build()
-        .inject(testGeneric);
+        .inject(testGeneric, new TypeToken<TestInjectGeneric<TestObject>>() {});
 
     assertThat(testGeneric.obj)
         .isNotNull()
@@ -127,7 +127,7 @@ public class GenericConstructorTest {
         .injector().javax()
         .dependency(TestObject.class, testMock)
         .build()
-        .inject(testGeneric);
+        .inject(testGeneric, new TypeToken<TestMethodInjectGeneric<TestObject>>() {});
 
     assertThat(testGeneric.obj)
         .isNotNull()

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/GenericConstructorTest.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/GenericConstructorTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import javax.inject.Inject;
 
@@ -100,5 +101,37 @@ public class GenericConstructorTest {
 
     assertThat(resources.testGeneric).isNotNull();
     assertThat(resources.testGeneric.obj).isNotNull().is(mockCondition());
+  }
+
+  @Test public void testFieldInjectionOfExistingObject() {
+    TestInjectGeneric<TestObject> testGeneric = new TestInjectGeneric<>();
+    TestObject testMock = Mockito.mock(TestObject.class);
+
+    mockspresso.buildUpon()
+        .injector().javax()
+        .dependency(TestObject.class, testMock)
+        .build()
+        .inject(testGeneric);
+
+    assertThat(testGeneric.obj)
+        .isNotNull()
+        .is(mockCondition())
+        .isEqualTo(testMock);
+  }
+
+  @Test public void testMethodInjectionOfExistingObject() {
+    TestMethodInjectGeneric<TestObject> testGeneric = new TestMethodInjectGeneric<>();
+    TestObject testMock = Mockito.mock(TestObject.class);
+
+    mockspresso.buildUpon()
+        .injector().javax()
+        .dependency(TestObject.class, testMock)
+        .build()
+        .inject(testGeneric);
+
+    assertThat(testGeneric.obj)
+        .isNotNull()
+        .is(mockCondition())
+        .isEqualTo(testMock);
   }
 }


### PR DESCRIPTION
We actually still have an issue related to what we discovered in https://github.com/episode6/mockspresso/pull/4

The problem is, if we try to inject dependencies into pre-existing objects via `Mockspresso.inject(Object)` we can fail if that object is a generic with TypeVariables defined as injected fields (or injected method parameters).

This PR adds a new signature to our Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`
This acts as a workaround for such cases, since we can now resolve these TypeVariables given a fully-formed TypeToken to work with.

This is still not ideal, because we don't throw an error atm when this occurs in existing code (instead we'll just mock an `Object` and return that). So I'll probably take another pass at adding a better error before merging.