### PR TITLE
[kotlin-support] Annotate api impls with null/notnull

### DIFF
--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
@@ -5,6 +5,7 @@ import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import com.episode6.hackit.mockspresso.util.Preconditions;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 import java.util.HashSet;
@@ -51,31 +52,34 @@ abstract class AbstractDelayedMockspresso implements Mockspresso, MockspressoInt
     return Preconditions.assertNotNull(mDelegate, ERROR_MESSAGE);
   }
 
+  @NotNull
   @Override
-  public <T> T create(Class<T> clazz) {
+  public <T> T create(@NotNull Class<T> clazz) {
     return getDelegate().create(clazz);
   }
 
+  @NotNull
   @Override
-  public <T> T create(TypeToken<T> typeToken) {
+  public <T> T create(@NotNull TypeToken<T> typeToken) {
     return getDelegate().create(typeToken);
   }
 
   @Override
-  public void inject(Object instance) {
+  public void inject(@NotNull Object instance) {
     getDelegate().inject(instance);
   }
 
   @Override
-  public <T> void inject(T instance, TypeToken<T> typeToken) {
+  public <T> void inject(@NotNull T instance, @NotNull TypeToken<T> typeToken) {
     getDelegate().inject(instance, typeToken);
   }
 
   @Override
-  public <T> T getDependency(DependencyKey<T> key) {
+  public <T> T getDependency(@NotNull DependencyKey<T> key) {
     return getDelegate().getDependency(key);
   }
 
+  @NotNull
   @Override
   public synchronized Builder buildUpon() {
     if (mDelegate != null) {

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/DelayedMockspressoBuilder.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/DelayedMockspressoBuilder.java
@@ -4,6 +4,7 @@ import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.api.*;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
+import org.jetbrains.annotations.NotNull;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 
@@ -39,139 +40,163 @@ class DelayedMockspressoBuilder extends AbstractDelayedMockspresso implements Mo
     }
   }
 
+  @NotNull
   @Override
-  public Builder plugin(MockspressoPlugin plugin) {
+  public Builder plugin(@NotNull MockspressoPlugin plugin) {
     mBuilder.plugin(plugin);
     return this;
   }
 
+  @NotNull
   @Override
-  public Builder outerRule(TestRule testRule) {
+  public Builder outerRule(@NotNull TestRule testRule) {
     throw new VerifyError("Can't build a new mockspresso @Rule on top of an existing one.");
   }
 
+  @NotNull
   @Override
-  public Builder outerRule(MethodRule methodRule) {
+  public Builder outerRule(@NotNull MethodRule methodRule) {
     throw new VerifyError("Can't build a new mockspresso @Rule on top of an existing one.");
   }
 
+  @NotNull
   @Override
-  public Builder innerRule(TestRule testRule) {
+  public Builder innerRule(@NotNull TestRule testRule) {
     throw new VerifyError("Can't build a new mockspresso @Rule on top of an existing one.");
   }
 
+  @NotNull
   @Override
-  public Builder innerRule(MethodRule methodRule) {
+  public Builder innerRule(@NotNull MethodRule methodRule) {
     throw new VerifyError("Can't build a new mockspresso @Rule on top of an existing one.");
   }
 
+  @NotNull
   @Override
-  public Builder testResources(Object objectWithResources) {
+  public Builder testResources(@NotNull Object objectWithResources) {
     mBuilder.testResources(objectWithResources);
     return this;
   }
 
+  @NotNull
   @Override
-  public Builder testResourcesWithoutLifecycle(Object objectWithResources) {
+  public Builder testResourcesWithoutLifecycle(@NotNull Object objectWithResources) {
     mBuilder.testResourcesWithoutLifecycle(objectWithResources);
     return this;
   }
 
+  @NotNull
   @Override
-  public Builder mocker(MockerConfig mockerConfig) {
+  public Builder mocker(@NotNull MockerConfig mockerConfig) {
     mBuilder.mocker(mockerConfig);
     return this;
   }
 
+  @NotNull
   @Override
-  public Builder injector(InjectionConfig injectionConfig) {
+  public Builder injector(@NotNull InjectionConfig injectionConfig) {
     mBuilder.injector(injectionConfig);
     return this;
   }
 
+  @NotNull
   @Override
-  public Builder specialObjectMaker(SpecialObjectMaker specialObjectMaker) {
+  public Builder specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker) {
     mBuilder.specialObjectMaker(specialObjectMaker);
     return this;
   }
 
+  @NotNull
   @Override
-  public Builder specialObjectMakers(List<SpecialObjectMaker> specialObjectMakers) {
+  public Builder specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers) {
     mBuilder.specialObjectMakers(specialObjectMakers);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Builder dependency(Class<T> clazz, V value) {
+  public <T, V extends T> Builder dependency(@NotNull Class<T> clazz, V value) {
     mBuilder.dependency(clazz, value);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Builder dependency(TypeToken<T> typeToken, V value) {
+  public <T, V extends T> Builder dependency(@NotNull TypeToken<T> typeToken, V value) {
     mBuilder.dependency(typeToken, value);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Builder dependency(DependencyKey<T> key, V value) {
+  public <T, V extends T> Builder dependency(@NotNull DependencyKey<T> key, V value) {
     mBuilder.dependency(key, value);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Builder dependencyProvider(Class<T> clazz, ObjectProvider<V> value) {
+  public <T, V extends T> Builder dependencyProvider(@NotNull Class<T> clazz, @NotNull ObjectProvider<V> value) {
     mBuilder.dependencyProvider(clazz, value);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Builder dependencyProvider(TypeToken<T> typeToken, ObjectProvider<V> value) {
+  public <T, V extends T> Builder dependencyProvider(@NotNull TypeToken<T> typeToken, @NotNull ObjectProvider<V> value) {
     mBuilder.dependencyProvider(typeToken, value);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Builder dependencyProvider(DependencyKey<T> key, ObjectProvider<V> value) {
+  public <T, V extends T> Builder dependencyProvider(@NotNull DependencyKey<T> key, @NotNull ObjectProvider<V> value) {
     mBuilder.dependencyProvider(key, value);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T> Builder realObject(Class<T> objectClass) {
+  public <T> Builder realObject(@NotNull Class<T> objectClass) {
     mBuilder.realObject(objectClass);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T> Builder realObject(TypeToken<T> objectToken) {
+  public <T> Builder realObject(@NotNull TypeToken<T> objectToken) {
     mBuilder.realObject(objectToken);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T> Builder realObject(DependencyKey<T> keyAndImplementation) {
+  public <T> Builder realObject(@NotNull DependencyKey<T> keyAndImplementation) {
     mBuilder.realObject(keyAndImplementation);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T> Builder realObject(DependencyKey<T> key, Class<? extends T> implementationClass) {
+  public <T> Builder realObject(@NotNull DependencyKey<T> key, @NotNull Class<? extends T> implementationClass) {
     mBuilder.realObject(key, implementationClass);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T> Builder realObject(DependencyKey<T> key, TypeToken<? extends T> implementationToken) {
+  public <T> Builder realObject(@NotNull DependencyKey<T> key, @NotNull TypeToken<? extends T> implementationToken) {
     mBuilder.realObject(key, implementationToken);
     return this;
   }
 
+  @NotNull
   @Override
   public Mockspresso build() {
     return this;
   }
 
+  @NotNull
   @Override
   public Rule buildRule() {
     throw new VerifyError("Can't build a new mockspresso @Rule on top of an existing one.");

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoBuilderImpl.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoBuilderImpl.java
@@ -8,6 +8,7 @@ import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import com.episode6.hackit.mockspresso.util.CollectionUtil;
 import com.episode6.hackit.mockspresso.util.Preconditions;
+import org.jetbrains.annotations.NotNull;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 
@@ -82,128 +83,151 @@ class MockspressoBuilderImpl implements Mockspresso.Builder {
     }
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder plugin(MockspressoPlugin plugin) {
+  public Mockspresso.Builder plugin(@NotNull MockspressoPlugin plugin) {
     return plugin.apply(this);
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder outerRule(TestRule testRule) {
+  public Mockspresso.Builder outerRule(@NotNull TestRule testRule) {
     mRuleConfig.addOuterRule(testRule);
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder outerRule(MethodRule methodRule) {
+  public Mockspresso.Builder outerRule(@NotNull MethodRule methodRule) {
     mRuleConfig.addOuterRule(methodRule);
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder innerRule(TestRule testRule) {
+  public Mockspresso.Builder innerRule(@NotNull TestRule testRule) {
     mRuleConfig.addInnerRule(testRule);
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder innerRule(MethodRule methodRule) {
+  public Mockspresso.Builder innerRule(@NotNull MethodRule methodRule) {
     mRuleConfig.addInnerRule(methodRule);
     return this;
   }
 
-  public Mockspresso.Builder testResources(Object objectWithResources) {
+  @NotNull
+  public Mockspresso.Builder testResources(@NotNull Object objectWithResources) {
     mTestResources.add(new TestResource(objectWithResources, true));
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder testResourcesWithoutLifecycle(Object objectWithResources) {
+  public Mockspresso.Builder testResourcesWithoutLifecycle(@NotNull Object objectWithResources) {
     mTestResources.add(new TestResource(objectWithResources, false));
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder mocker(MockerConfig mockerConfig) {
+  public Mockspresso.Builder mocker(@NotNull MockerConfig mockerConfig) {
     mMockerConfig = mockerConfig;
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder injector(InjectionConfig injectionConfig) {
+  public Mockspresso.Builder injector(@NotNull InjectionConfig injectionConfig) {
     mInjectionConfig = injectionConfig;
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder specialObjectMaker(SpecialObjectMaker specialObjectMaker) {
+  public Mockspresso.Builder specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker) {
     mSpecialObjectMakers.add(specialObjectMaker);
     return this;
   }
 
+  @NotNull
   @Override
-  public Mockspresso.Builder specialObjectMakers(List<SpecialObjectMaker> specialObjectMakers) {
+  public Mockspresso.Builder specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers) {
     mSpecialObjectMakers.addAll(specialObjectMakers);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Mockspresso.Builder dependency(Class<T> clazz, V value) {
+  public <T, V extends T> Mockspresso.Builder dependency(@NotNull Class<T> clazz, V value) {
     return dependency(DependencyKey.of(clazz), value);
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Mockspresso.Builder dependency(TypeToken<T> typeToken, V value) {
+  public <T, V extends T> Mockspresso.Builder dependency(@NotNull TypeToken<T> typeToken, V value) {
     return dependency(DependencyKey.of(typeToken), value);
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Mockspresso.Builder dependency(DependencyKey<T> key, V value) {
+  public <T, V extends T> Mockspresso.Builder dependency(@NotNull DependencyKey<T> key, V value) {
     mDependencyMap.put(key, value, null);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Mockspresso.Builder dependencyProvider(Class<T> clazz, ObjectProvider<V> value) {
+  public <T, V extends T> Mockspresso.Builder dependencyProvider(@NotNull Class<T> clazz, @NotNull ObjectProvider<V> value) {
     return dependencyProvider(DependencyKey.of(clazz), value);
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Mockspresso.Builder dependencyProvider(TypeToken<T> typeToken, ObjectProvider<V> value) {
+  public <T, V extends T> Mockspresso.Builder dependencyProvider(@NotNull TypeToken<T> typeToken, @NotNull ObjectProvider<V> value) {
     return dependencyProvider(DependencyKey.of(typeToken), value);
   }
 
+  @NotNull
   @Override
-  public <T, V extends T> Mockspresso.Builder dependencyProvider(DependencyKey<T> key, ObjectProvider<V> value) {
+  public <T, V extends T> Mockspresso.Builder dependencyProvider(@NotNull DependencyKey<T> key, @NotNull ObjectProvider<V> value) {
     mDependencyMap.putProvider(key, value, null);
     return this;
   }
 
+  @NotNull
   @Override
-  public <T> Mockspresso.Builder realObject(Class<T> objectClass) {
+  public <T> Mockspresso.Builder realObject(@NotNull Class<T> objectClass) {
     return realObject(TypeToken.of(objectClass));
   }
 
+  @NotNull
   @Override
-  public <T> Mockspresso.Builder realObject(TypeToken<T> objectToken) {
+  public <T> Mockspresso.Builder realObject(@NotNull TypeToken<T> objectToken) {
     return realObject(DependencyKey.of(objectToken));
   }
 
+  @NotNull
   @Override
-  public <T> Mockspresso.Builder realObject(DependencyKey<T> keyAndImplementation) {
+  public <T> Mockspresso.Builder realObject(@NotNull DependencyKey<T> keyAndImplementation) {
     return realObject(keyAndImplementation, keyAndImplementation.typeToken);
   }
 
+  @NotNull
   @Override
-  public <T> Mockspresso.Builder realObject(DependencyKey<T> key, Class<? extends T> implementationClass) {
+  public <T> Mockspresso.Builder realObject(@NotNull DependencyKey<T> key, @NotNull Class<? extends T> implementationClass) {
     return realObject(key, TypeToken.of(implementationClass));
   }
 
+  @NotNull
   @Override
-  public <T> Mockspresso.Builder realObject(DependencyKey<T> key, TypeToken<? extends T> implementationToken) {
+  public <T> Mockspresso.Builder realObject(@NotNull DependencyKey<T> key, @NotNull TypeToken<? extends T> implementationToken) {
     mRealObjectMapping.put(key, implementationToken, false);
     return this;
   }
 
+  @NotNull
   @Override
   public Mockspresso build() {
     if (!mRuleConfig.isEmpty()) {
@@ -214,6 +238,7 @@ class MockspressoBuilderImpl implements Mockspresso.Builder {
     return instance;
   }
 
+  @NotNull
   @Override
   public Mockspresso.Rule buildRule() {
     return new MockspressoRuleImpl(

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoImpl.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoImpl.java
@@ -4,6 +4,7 @@ import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.api.DependencyProvider;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Provider;
 
@@ -28,13 +29,15 @@ class MockspressoImpl implements Mockspresso, MockspressoInternal {
     mBuilderProvider = builderProvider;
   }
 
+  @NotNull
   @Override
-  public <T> T create(Class<T> clazz) {
+  public <T> T create(@NotNull Class<T> clazz) {
     return create(TypeToken.of(clazz));
   }
 
+  @NotNull
   @Override
-  public <T> T create(TypeToken<T> typeToken) {
+  public <T> T create(@NotNull TypeToken<T> typeToken) {
     DependencyProvider dependencyProvider = mDependencyProviderFactory.getDependencyProviderFor(
         DependencyKey.of(typeToken));
     return mRealObjectMaker.createObject(
@@ -43,12 +46,12 @@ class MockspressoImpl implements Mockspresso, MockspressoInternal {
   }
 
   @Override
-  public void inject(Object instance) {
+  public void inject(@NotNull Object instance) {
     injectInternal(instance, TypeToken.of(instance.getClass()));
   }
 
   @Override
-  public <T> void inject(T instance, TypeToken<T> typeToken) {
+  public <T> void inject(@NotNull T instance, @NotNull TypeToken<T> typeToken) {
     injectInternal(instance, typeToken);
   }
 
@@ -62,10 +65,11 @@ class MockspressoImpl implements Mockspresso, MockspressoInternal {
   }
 
   @Override
-  public <T> T getDependency(DependencyKey<T> key) {
+  public <T> T getDependency(@NotNull DependencyKey<T> key) {
     return mDependencyProviderFactory.getBlankDependencyProvider().get(key);
   }
 
+  @NotNull
   @Override
   public Builder buildUpon() {
     MockspressoBuilderImpl builder = mBuilderProvider.get();

--- a/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
+++ b/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
@@ -4,6 +4,7 @@ import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.api.*;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
+import org.jetbrains.annotations.NotNull;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 import org.junit.runners.model.FrameworkMethod;
@@ -35,44 +36,47 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
    * @param <OUT> Output type - one of your custom mockspresso extension's types
    */
   protected interface Wrapper<IN, OUT> {
-    OUT wrap(IN delegate);
+    @NotNull OUT wrap(@NotNull IN delegate);
   }
 
   private final Mockspresso mDelegate;
   private final Wrapper<Mockspresso.Builder, BLDR> mBuilderWrapper;
 
   protected AbstractMockspressoExtension(
-      Mockspresso delegate,
-      Wrapper<Mockspresso.Builder, BLDR> builderWrapper) {
+      @NotNull Mockspresso delegate,
+      @NotNull Wrapper<Mockspresso.Builder, BLDR> builderWrapper) {
     mDelegate = delegate;
     mBuilderWrapper = builderWrapper;
   }
 
+  @NotNull
   @Override
-  public <T> T create(Class<T> clazz) {
+  public <T> T create(@NotNull Class<T> clazz) {
     return mDelegate.create(clazz);
   }
 
+  @NotNull
   @Override
-  public <T> T create(TypeToken<T> typeToken) {
+  public <T> T create(@NotNull TypeToken<T> typeToken) {
     return mDelegate.create(typeToken);
   }
 
   @Override
-  public void inject(Object instance) {
+  public void inject(@NotNull Object instance) {
     mDelegate.inject(instance);
   }
 
   @Override
-  public <T> void inject(T instance, TypeToken<T> typeToken) {
+  public <T> void inject(@NotNull T instance, @NotNull TypeToken<T> typeToken) {
     mDelegate.inject(instance, typeToken);
   }
 
   @Override
-  public <T> T getDependency(DependencyKey<T> key) {
+  public <T> T getDependency(@NotNull DependencyKey<T> key) {
     return mDelegate.getDependency(key);
   }
 
+  @NotNull
   @Override
   public BLDR buildUpon() {
     return mBuilderWrapper.wrap(mDelegate.buildUpon());
@@ -91,37 +95,40 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
     private final Wrapper<Mockspresso.Builder, BLDR> mBuilderWrapper;
 
     protected Rule(
-        Rule delegate,
-        Wrapper<Builder, BLDR> builderWrapper) {
+        @NotNull Rule delegate,
+        @NotNull Wrapper<Builder, BLDR> builderWrapper) {
       mDelegate = delegate;
       mBuilderWrapper = builderWrapper;
     }
 
+    @NotNull
     @Override
-    public <T> T create(Class<T> clazz) {
+    public <T> T create(@NotNull Class<T> clazz) {
       return mDelegate.create(clazz);
     }
 
+    @NotNull
     @Override
-    public <T> T create(TypeToken<T> typeToken) {
+    public <T> T create(@NotNull TypeToken<T> typeToken) {
       return mDelegate.create(typeToken);
     }
 
     @Override
-    public void inject(Object instance) {
+    public void inject(@NotNull Object instance) {
       mDelegate.inject(instance);
     }
 
     @Override
-    public <T> void inject(T instance, TypeToken<T> typeToken) {
+    public <T> void inject(@NotNull T instance, @NotNull TypeToken<T> typeToken) {
       mDelegate.inject(instance, typeToken);
     }
 
     @Override
-    public <T> T getDependency(DependencyKey<T> key) {
+    public <T> T getDependency(@NotNull DependencyKey<T> key) {
       return mDelegate.getDependency(key);
     }
 
+    @NotNull
     @Override
     public BLDR buildUpon() {
       return mBuilderWrapper.wrap(mDelegate.buildUpon());
@@ -156,152 +163,176 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
     private final Wrapper<Mockspresso.Rule, RULE> mRuleWrapper;
 
     protected Builder(
-        Mockspresso.Builder delegate,
-        Wrapper<Mockspresso, EXT> extensionWrapper,
-        Wrapper<Mockspresso.Rule, RULE> ruleWrapper) {
+        @NotNull Mockspresso.Builder delegate,
+        @NotNull Wrapper<Mockspresso, EXT> extensionWrapper,
+        @NotNull Wrapper<Mockspresso.Rule, RULE> ruleWrapper) {
       mDelegate = delegate;
       mExtensionWrapper = extensionWrapper;
       mRuleWrapper = ruleWrapper;
     }
 
+    @NotNull
     @Override
     public EXT build() {
       return mExtensionWrapper.wrap(mDelegate.build());
     }
 
+    @NotNull
     @Override
     public RULE buildRule() {
       return mRuleWrapper.wrap(mDelegate.buildRule());
     }
 
+    @NotNull
     @Override
-    public BLDR plugin(MockspressoPlugin plugin) {
+    public BLDR plugin(@NotNull MockspressoPlugin plugin) {
       mDelegate.plugin(plugin);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR outerRule(TestRule testRule) {
+    public BLDR outerRule(@NotNull TestRule testRule) {
       mDelegate.outerRule(testRule);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR outerRule(MethodRule methodRule) {
+    public BLDR outerRule(@NotNull MethodRule methodRule) {
       mDelegate.outerRule(methodRule);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR innerRule(TestRule testRule) {
+    public BLDR innerRule(@NotNull TestRule testRule) {
       mDelegate.innerRule(testRule);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR innerRule(MethodRule methodRule) {
+    public BLDR innerRule(@NotNull MethodRule methodRule) {
       mDelegate.innerRule(methodRule);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR testResources(Object objectWithResources) {
+    public BLDR testResources(@NotNull Object objectWithResources) {
       mDelegate.testResources(objectWithResources);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR testResourcesWithoutLifecycle(Object objectWithResources) {
+    public BLDR testResourcesWithoutLifecycle(@NotNull Object objectWithResources) {
       mDelegate.testResourcesWithoutLifecycle(objectWithResources);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR mocker(MockerConfig mockerConfig) {
+    public BLDR mocker(@NotNull MockerConfig mockerConfig) {
       mDelegate.mocker(mockerConfig);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR injector(InjectionConfig injectionConfig) {
+    public BLDR injector(@NotNull InjectionConfig injectionConfig) {
       mDelegate.injector(injectionConfig);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR specialObjectMaker(SpecialObjectMaker specialObjectMaker) {
+    public BLDR specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker) {
       mDelegate.specialObjectMaker(specialObjectMaker);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public BLDR specialObjectMakers(List<SpecialObjectMaker> specialObjectMakers) {
+    public BLDR specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers) {
       mDelegate.specialObjectMakers(specialObjectMakers);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T, V extends T> BLDR dependency(Class<T> clazz, V value) {
+    public <T, V extends T> BLDR dependency(@NotNull Class<T> clazz, V value) {
       mDelegate.dependency(clazz, value);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T, V extends T> BLDR dependency(TypeToken<T> typeToken, V value) {
+    public <T, V extends T> BLDR dependency(@NotNull TypeToken<T> typeToken, V value) {
       mDelegate.dependency(typeToken, value);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T, V extends T> BLDR dependency(DependencyKey<T> key, V value) {
+    public <T, V extends T> BLDR dependency(@NotNull DependencyKey<T> key, V value) {
       mDelegate.dependency(key, value);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T, V extends T> BLDR dependencyProvider(Class<T> clazz, ObjectProvider<V> value) {
+    public <T, V extends T> BLDR dependencyProvider(@NotNull Class<T> clazz, @NotNull ObjectProvider<V> value) {
       mDelegate.dependencyProvider(clazz, value);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T, V extends T> BLDR dependencyProvider(TypeToken<T> typeToken, ObjectProvider<V> value) {
+    public <T, V extends T> BLDR dependencyProvider(@NotNull TypeToken<T> typeToken, @NotNull ObjectProvider<V> value) {
       mDelegate.dependencyProvider(typeToken, value);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T, V extends T> BLDR dependencyProvider(DependencyKey<T> key, ObjectProvider<V> value) {
+    public <T, V extends T> BLDR dependencyProvider(@NotNull DependencyKey<T> key, @NotNull ObjectProvider<V> value) {
       mDelegate.dependencyProvider(key, value);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T> BLDR realObject(Class<T> objectClass) {
+    public <T> BLDR realObject(@NotNull Class<T> objectClass) {
       mDelegate.realObject(objectClass);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T> BLDR realObject(TypeToken<T> objectToken) {
+    public <T> BLDR realObject(@NotNull TypeToken<T> objectToken) {
       mDelegate.realObject(objectToken);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T> BLDR realObject(DependencyKey<T> keyAndImplementation) {
+    public <T> BLDR realObject(@NotNull DependencyKey<T> keyAndImplementation) {
       mDelegate.realObject(keyAndImplementation);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T> BLDR realObject(DependencyKey<T> key, Class<? extends T> implementationClass) {
+    public <T> BLDR realObject(@NotNull DependencyKey<T> key, @NotNull Class<? extends T> implementationClass) {
       mDelegate.realObject(key, implementationClass);
       return (BLDR) this;
     }
 
+    @NotNull
     @Override
-    public <T> BLDR realObject(DependencyKey<T> key, TypeToken<? extends T> implementationToken) {
+    public <T> BLDR realObject(@NotNull DependencyKey<T> key, @NotNull TypeToken<? extends T> implementationToken) {
       mDelegate.realObject(key, implementationToken);
       return (BLDR) this;
     }

--- a/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspressoImpl.java
+++ b/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspressoImpl.java
@@ -3,19 +3,20 @@ package com.episode6.hackit.mockspresso.quick;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.extend.AbstractMockspressoExtension;
 import com.episode6.hackit.mockspresso.quick.exception.MissingDependencyError;
+import org.jetbrains.annotations.NotNull;
 
 /**
  *
  */
 class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso.Builder> implements QuickMockspresso {
 
-  private QuickMockspressoImpl(Mockspresso delegate) {
+  private QuickMockspressoImpl(@NotNull Mockspresso delegate) {
     super(delegate, Builder::new);
   }
 
   static class Rule extends AbstractMockspressoExtension.Rule<QuickMockspresso.Builder> implements QuickMockspresso.Rule {
 
-    private Rule(Rule delegate) {
+    private Rule(@NotNull Rule delegate) {
       super(delegate, QuickMockspressoImpl.Builder::new);
     }
   }
@@ -27,21 +28,24 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
 
     private final PluginPickerImpl mPluginPicker;
 
-    Builder(Mockspresso.Builder delegate) {
+    Builder(@NotNull Mockspresso.Builder delegate) {
       super(delegate, QuickMockspressoImpl::new, Rule::new);
       mPluginPicker = new PluginPickerImpl(this);
     }
 
+    @NotNull
     @Override
     public InjectorPicker injector() {
       return mPluginPicker;
     }
 
+    @NotNull
     @Override
     public PluginPicker plugin() {
       return mPluginPicker;
     }
 
+    @NotNull
     @Override
     public MockerPicker mocker() {
       return mPluginPicker;
@@ -56,16 +60,19 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       mBuilder = builder;
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder simple() {
       return mBuilder.plugin(new com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin());
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder javax() {
       return mBuilder.plugin(new com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin());
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder dagger() {
       try {
@@ -75,6 +82,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder mockito() {
       try {
@@ -84,6 +92,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder easyMock() {
       try {
@@ -93,6 +102,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder mockitoWithPowerMock() {
       try {
@@ -104,6 +114,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder mockitoWithPowerMockRule() {
       try {
@@ -115,6 +126,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder easyMockWithPowerMock() {
       try {
@@ -126,6 +138,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder easyMockWithPowerMockRule() {
       try {
@@ -137,6 +150,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder guava() {
       try {
@@ -146,6 +160,7 @@ class QuickMockspressoImpl extends AbstractMockspressoExtension<QuickMockspresso
       }
     }
 
+    @NotNull
     @Override
     public QuickMockspresso.Builder automaticFactories(Class<?>... factoryClasses) {
       try {


### PR DESCRIPTION
In our kotlin intro, we annotated all our interfaces with @Nullable/@NotNull to better support kotlin users. This left us with a bunch of gross warnings throughout the whole project. Kill those warnings by annotating our implementations as well. 

This PR is mostly just IntelliJ fixing the errors automatically. Although we also manually annotated the MockspressoExtension's `Wrapper` interface which was missed in the first pass.