### PR TITLE
Kill retrolambda and target java 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - Add kotlin support
  - Replace jsr305 with jetbrains annotations
  - Annotate interfaces null/not null for kotlin compatibility
+ - Removed retrolambda and targeted Java 8
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  - Add kotlin support
  - Replace jsr305 with jetbrains annotations
  - Annotate interfaces null/not null for kotlin compatibility
- - Removed retrolambda and targeted Java 8
+ - Remove retrolambda and target Java 8
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -17,7 +17,6 @@ apply plugin: 'com.episode6.hackit.gdmc'
 dependencies {
   runtimeClasspath 'com.episode6.hackit.gdmc:gdmc'
   runtimeClasspath 'com.episode6.hackit.deployable:deployable'
-  runtimeClasspath 'me.tatarka:gradle-retrolambda'
   runtimeClasspath 'org.jetbrains.kotlin:kotlin-gradle-plugin'
   runtimeClasspath 'org.jetbrains.dokka:dokka-gradle-plugin'
 }

--- a/buildSrc/src/main/groovy/JavaProject.groovy
+++ b/buildSrc/src/main/groovy/JavaProject.groovy
@@ -11,17 +11,12 @@ class JavaProject implements Plugin<Project> {
       plugins.with {
         apply 'java-library'
         apply 'kotlin'
-        apply 'me.tatarka.retrolambda'
         applyDeployablePlugin(it)
         apply 'com.episode6.hackit.gdmc'
       }
 
       sourceCompatibility = 1.8
       targetCompatibility = 1.8
-
-      retrolambda {
-        javaVersion JavaVersion.VERSION_1_7
-      }
 
       dependencies {
         implementation 'org.jetbrains.kotlin:kotlin-stdlib'


### PR DESCRIPTION
Removes retrolambda dependency and targets java8.

Actually triggers a very odd bug where one of the lambdas in our QuickBuilder fails with NPEs when attempting to buildUpon a rule using the easyMockWithPowerMock mocker. 

The failures are now fixed by https://github.com/episode6/mockspresso/pull/11