### PR TITLE
Add kotlin extensions to create TypeTokens and DependencyKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
  - Annotate interfaces null/not null for kotlin compatibility
  - Remove retrolambda and target Java 8
  - Hide internal entry-point using kotlin `internal` visibility that was formerly public but not intended for public use.
+ - Added kotlin extension methods using reified types to reduce verbosity
+     - `typeToken<T>()`: Create a `TypeToken<T>`
+     - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier.  
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/DependencyKey.java
+++ b/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/DependencyKey.java
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.reflect;
 
 import org.jetbrains.annotations.Nullable;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 
@@ -17,11 +18,11 @@ public final class DependencyKey<V> {
     return new DependencyKey<T>(typeToken, null);
   }
 
-  public static <T> DependencyKey<T> of(Class<T> clazz, Annotation identityAnnotation) {
+  public static <T> DependencyKey<T> of(Class<T> clazz, @Nullable Annotation identityAnnotation) {
     return of(TypeToken.of(clazz), identityAnnotation);
   }
 
-  public static <T> DependencyKey<T> of(TypeToken<T> typeToken, Annotation identityAnnotation) {
+  public static <T> DependencyKey<T> of(TypeToken<T> typeToken, @Nullable Annotation identityAnnotation) {
     return new DependencyKey<T>(typeToken, identityAnnotation);
   }
 

--- a/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
+++ b/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
@@ -1,0 +1,17 @@
+package com.episode6.hackit.mockspresso.reflect
+
+/**
+ * Kotlin extensions for reflection utils using reified type parameters
+ */
+
+/**
+ * Creates a [TypeToken] for [T]
+ */
+inline fun <reified T : Any> typeToken(): TypeToken<T> =
+    object : TypeToken<T>() {}
+
+/**
+ * Creates a [DependencyKey] for [T] with the provided qualifier annotation
+ */
+inline fun <reified T : Any> dependencyKey(qualifier: Annotation? = null): DependencyKey<T> =
+    DependencyKey.of<T>(typeToken<T>(), qualifier)

--- a/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
+++ b/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
@@ -7,8 +7,7 @@ package com.episode6.hackit.mockspresso.reflect
 /**
  * Creates a [TypeToken] for [T]
  */
-inline fun <reified T : Any> typeToken(): TypeToken<T> =
-    object : TypeToken<T>() {}
+inline fun <reified T : Any> typeToken(): TypeToken<T> = object : TypeToken<T>() {}
 
 /**
  * Creates a [DependencyKey] for [T] with the provided qualifier annotation

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/DependencyKeyKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/DependencyKeyKotlinTest.kt
@@ -1,0 +1,63 @@
+package com.episode6.hackit.mockspresso.reflect
+
+import com.episode6.hackit.mockspresso.reflect.testobject.JavaTokens
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Test
+import java.util.*
+
+/**
+ *
+ */
+class DependencyKeyKotlinTest {
+
+  @Test fun testStringKey() {
+    val key = dependencyKey<String>()
+
+    assertThat(key).isEqualTo(JavaTokens.stringKey)
+  }
+
+  @Test fun testNamedIntKey() {
+    val namedKey = dependencyKey<Int>(NamedAnnotationLiteral("intKey"))
+    val unnamedKey = dependencyKey<Int>()
+
+    assertThat(JavaTokens.intKey)
+        .isEqualTo(namedKey)
+        .isNotEqualTo(unnamedKey)
+  }
+
+  @Test fun testStringListKey() {
+    val key = dependencyKey<List<String>>()
+
+    assertThat(key).isEqualTo(JavaTokens.stringListKey)
+  }
+
+  @Test fun testStringIntMapKey() {
+    val key = dependencyKey<Map<String, Int>>()
+
+    assertThat(key).isEqualTo(JavaTokens.stringIntMapKey)
+  }
+
+  @Test fun testStringMutableListKey() {
+    val key =  dependencyKey<MutableList<String>>()
+
+    assertThat(key).isEqualTo(JavaTokens.stringMutableListKey)
+  }
+
+  @Test fun testStringIntMutableMapKey() {
+    val key =  dependencyKey<MutableMap<String, Int>>()
+
+    assertThat(key).isEqualTo(JavaTokens.stringIntMutableMapKey)
+  }
+
+  @Test fun testStringLinkedListKey() {
+    val key =  dependencyKey<LinkedList<String>>()
+
+    assertThat(key).isEqualTo(JavaTokens.stringLinkedListKey)
+  }
+
+  @Test fun testStringIntHashMapKey() {
+    val key =  dependencyKey<HashMap<String, Int>>()
+
+    assertThat(key).isEqualTo(JavaTokens.stringIntHashMapKey)
+  }
+}

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
@@ -1,6 +1,6 @@
 package com.episode6.hackit.mockspresso.reflect
 
-import com.episode6.hackit.mockspresso.reflect.testobject.JavaTypeTokens
+import com.episode6.hackit.mockspresso.reflect.testobject.JavaTokens
 import com.episode6.hackit.mockspresso.reflect.testobject.TestGenericKtInterface
 import com.episode6.hackit.mockspresso.reflect.testobject.TestJavaObjectWithKtGeneric
 import org.fest.assertions.api.Assertions.assertThat
@@ -15,49 +15,49 @@ class TypeTokenKotlinTest {
   @Test fun testStringToken() {
     val token = typeToken<String>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.stringToken)
+    assertThat(token).isEqualTo(JavaTokens.stringToken)
   }
 
   @Test fun testIntToken() {
     val token = typeToken<Int>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.intToken)
+    assertThat(token).isEqualTo(JavaTokens.intToken)
   }
 
   @Test fun testStringListToken() {
     val token = typeToken<List<String>>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
+    assertThat(token).isEqualTo(JavaTokens.stringListToken)
   }
 
-  @Test fun testStringIntMapTokenToken() {
+  @Test fun testStringIntMapToken() {
     val token = typeToken<Map<String, Int>>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.stringIntMapToken)
+    assertThat(token).isEqualTo(JavaTokens.stringIntMapToken)
   }
 
   @Test fun testStringMutableListToken() {
     val token = typeToken<MutableList<String>>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.stringMutableListToken)
+    assertThat(token).isEqualTo(JavaTokens.stringMutableListToken)
   }
 
-  @Test fun testStringIntMutableMapTokenToken() {
+  @Test fun testStringIntMutableMapToken() {
     val token = typeToken<MutableMap<String, Int>>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.stringIntMutableMapToken)
+    assertThat(token).isEqualTo(JavaTokens.stringIntMutableMapToken)
   }
 
   @Test fun testStringLinkedListToken() {
     val token = typeToken<LinkedList<String>>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.stringLinkedListToken)
+    assertThat(token).isEqualTo(JavaTokens.stringLinkedListToken)
   }
 
-  @Test fun testStringIntHashMapTokenToken() {
+  @Test fun testStringIntHashMapToken() {
     val token = typeToken<HashMap<String, Int>>()
 
-    assertThat(token).isEqualTo(JavaTypeTokens.stringIntHashMapToken)
+    assertThat(token).isEqualTo(JavaTokens.stringIntHashMapToken)
   }
 
   /**
@@ -92,7 +92,7 @@ class TypeTokenKotlinTest {
   @Test fun testKotlinGenericWithoutTypeMatchesJavaToken() {
     // if we create the the TypeToken in a java file in the same incorrect way the
     // TestJavaObjectWithKtGeneric defines it's field, the tokens now match.
-    val manualJavaToken = JavaTypeTokens.genericInterfaceIllegalToken
+    val manualJavaToken = JavaTokens.genericInterfaceIllegalToken
     val testObj = TestJavaObjectWithKtGeneric()
     val fieldToken = TypeToken.of(testObj.genericIfaceField.genericType)
 

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
@@ -1,0 +1,48 @@
+package com.episode6.hackit.mockspresso.reflect
+
+import com.episode6.hackit.mockspresso.reflect.testobject.JavaTypeTokens
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Test
+import java.util.*
+
+/**
+ * Tests the TypeToken class
+ */
+class TypeTokenKotlinTest {
+
+  @Test fun testStringToken() {
+    val token = typeToken<String>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringToken)
+  }
+
+  @Test fun testIntToken() {
+    val token = typeToken<Int>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.intToken)
+  }
+
+  @Test fun testStringListToken() {
+    val token = typeToken<List<String>>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
+  }
+
+  @Test fun testStringIntMapTokenToken() {
+    val token = typeToken<Map<String, Int>>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringIntMapToken)
+  }
+
+  @Test fun testStringLinkedListToken() {
+    val token = typeToken<LinkedList<String>>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringLinkedListToken)
+  }
+
+  @Test fun testStringIntHashMapTokenToken() {
+    val token = typeToken<HashMap<String, Int>>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringIntHashMapToken)
+  }
+}

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
@@ -28,6 +28,12 @@ class TypeTokenKotlinTest {
     assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
   }
 
+  @Test fun testStringListTokenManual() {
+    val token: TypeToken<List<String>> = object : TypeToken<List<String>>() {}
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
+  }
+
   @Test fun testStringIntMapTokenToken() {
     val token = typeToken<Map<String, Int>>()
 

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
@@ -25,23 +25,27 @@ class TypeTokenKotlinTest {
   }
 
   @Test fun testStringListToken() {
-    // using a MutableList causes the type to be cast to List without the `out` type variable
-    // thus this test starts passing
-    val token = typeToken<MutableList<String>>()
-
-    assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
-  }
-
-  @Test fun testStringListTokenManual() {
-    val token: TypeToken<MutableList<String>> = object : TypeToken<MutableList<String>>() {}
+    val token = typeToken<List<String>>()
 
     assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
   }
 
   @Test fun testStringIntMapTokenToken() {
-    val token = typeToken<MutableMap<String, Int>>()
+    val token = typeToken<Map<String, Int>>()
 
     assertThat(token).isEqualTo(JavaTypeTokens.stringIntMapToken)
+  }
+
+  @Test fun testStringMutableListToken() {
+    val token = typeToken<MutableList<String>>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringMutableListToken)
+  }
+
+  @Test fun testStringIntMutableMapTokenToken() {
+    val token = typeToken<MutableMap<String, Int>>()
+
+    assertThat(token).isEqualTo(JavaTypeTokens.stringIntMutableMapToken)
   }
 
   @Test fun testStringLinkedListToken() {
@@ -56,12 +60,42 @@ class TypeTokenKotlinTest {
     assertThat(token).isEqualTo(JavaTypeTokens.stringIntHashMapToken)
   }
 
-  @Test
-  fun testKotlinGeneric() {
-    val testObj = TestJavaObjectWithKtGeneric()
+  /**
+   * This test basically documents a kind of broken pattern in kotlin/java interop
+   * where mockspresso is concerned. We're parsing the TypeToken from a java class, but
+   * the field type is a generic Kotlin interface, and the declaration of the field ignores
+   * the `out` keyword on the type variable (i.e. it doesn't include `? extends` like
+   * generated kotlin code would).
+   *
+   * As a result these two tokens that *should* match, don't. We test just so we can have signal
+   * if/when this behavior changes, and to document it.
+   */
+  @Test fun testKotlinGenericWithOutTypeFails() {
+    // the `out` keyword on `TestGenericKtInterface's TypeVariable, means this token  actually
+    // looks like `TestGenericKtInterface<? extends String>`
     val manualToken = typeToken<TestGenericKtInterface<String>>()
+
+    // this class (written in java) delclares a field that *should* match the token above,
+    // but doesn't because its missing `? extends`
+    val testObj = TestJavaObjectWithKtGeneric()
     val fieldToken = TypeToken.of(testObj.genericIfaceField.genericType)
 
-    assertThat(fieldToken).isEqualTo(manualToken)
+    // we test this just so we can know if/when this behavior ever changes
+    // ideally we actually want these two tokens to be equal.
+    assertThat(fieldToken).isNotEqualTo(manualToken)
+  }
+
+  /**
+   * This test just demonstrates that we can use typeTokens defines/scanned in java to work
+   * around the issue described in the above test.
+   */
+  @Test fun testKotlinGenericWithoutTypeMatchesJavaToken() {
+    // if we create the the TypeToken in a java file in the same incorrect way the
+    // TestJavaObjectWithKtGeneric defines it's field, the tokens now match.
+    val manualJavaToken = JavaTypeTokens.genericInterfaceIllegalToken
+    val testObj = TestJavaObjectWithKtGeneric()
+    val fieldToken = TypeToken.of(testObj.genericIfaceField.genericType)
+
+    assertThat(fieldToken).isEqualTo(manualJavaToken)
   }
 }

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
@@ -1,6 +1,8 @@
 package com.episode6.hackit.mockspresso.reflect
 
 import com.episode6.hackit.mockspresso.reflect.testobject.JavaTypeTokens
+import com.episode6.hackit.mockspresso.reflect.testobject.TestGenericKtInterface
+import com.episode6.hackit.mockspresso.reflect.testobject.TestJavaObjectWithKtGeneric
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Test
 import java.util.*
@@ -52,5 +54,14 @@ class TypeTokenKotlinTest {
     val token = typeToken<HashMap<String, Int>>()
 
     assertThat(token).isEqualTo(JavaTypeTokens.stringIntHashMapToken)
+  }
+
+  @Test
+  fun testKotlinGeneric() {
+    val testObj = TestJavaObjectWithKtGeneric()
+    val manualToken = typeToken<TestGenericKtInterface<String>>()
+    val fieldToken = TypeToken.of(testObj.genericIfaceField.genericType)
+
+    assertThat(fieldToken).isEqualTo(manualToken)
   }
 }

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
@@ -86,7 +86,7 @@ class TypeTokenKotlinTest {
   }
 
   /**
-   * This test just demonstrates that we can use typeTokens defines/scanned in java to work
+   * This test just demonstrates that we can use typeTokens defined in java to work
    * around the issue described in the above test.
    */
   @Test fun testKotlinGenericWithoutTypeMatchesJavaToken() {

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenKotlinTest.kt
@@ -23,19 +23,21 @@ class TypeTokenKotlinTest {
   }
 
   @Test fun testStringListToken() {
-    val token = typeToken<List<String>>()
+    // using a MutableList causes the type to be cast to List without the `out` type variable
+    // thus this test starts passing
+    val token = typeToken<MutableList<String>>()
 
     assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
   }
 
   @Test fun testStringListTokenManual() {
-    val token: TypeToken<List<String>> = object : TypeToken<List<String>>() {}
+    val token: TypeToken<MutableList<String>> = object : TypeToken<MutableList<String>>() {}
 
     assertThat(token).isEqualTo(JavaTypeTokens.stringListToken)
   }
 
   @Test fun testStringIntMapTokenToken() {
-    val token = typeToken<Map<String, Int>>()
+    val token = typeToken<MutableMap<String, Int>>()
 
     assertThat(token).isEqualTo(JavaTypeTokens.stringIntMapToken)
   }

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenTest.java
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/TypeTokenTest.java
@@ -1,5 +1,7 @@
 package com.episode6.hackit.mockspresso.reflect;
 
+import com.episode6.hackit.mockspresso.reflect.testobject.TestGenericKtInterface;
+import com.episode6.hackit.mockspresso.reflect.testobject.TestJavaObjectWithKtGeneric;
 import org.junit.Test;
 
 import java.lang.reflect.ParameterizedType;
@@ -98,5 +100,14 @@ public class TypeTokenTest {
     TypeToken<HashMap<String, Integer>> manualHashmapTypeToken = new TypeToken<HashMap<String, Integer>>() {};
     assertThat(stringListToken).isEqualTo(manualStringListToken);
     assertThat(hashmapTypeToken).isEqualTo(manualHashmapTypeToken);
+  }
+
+  @Test
+  public void testKotlinGeneric() {
+    TestJavaObjectWithKtGeneric testObj = new TestJavaObjectWithKtGeneric();
+    TypeToken<TestGenericKtInterface<String>> manualToken = new TypeToken<TestGenericKtInterface<String>>() {};
+    TypeToken fieldToken = TypeToken.of(testObj.getGenericIfaceField().getGenericType());
+
+    assertThat(manualToken).isEqualTo(fieldToken);
   }
 }

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/JavaTokens.java
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/JavaTokens.java
@@ -1,5 +1,7 @@
 package com.episode6.hackit.mockspresso.reflect.testobject;
 
+import com.episode6.hackit.mockspresso.reflect.DependencyKey;
+import com.episode6.hackit.mockspresso.reflect.NamedAnnotationLiteral;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 
 import java.util.HashMap;
@@ -8,26 +10,36 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Some type tokens, declared in java, used by kotlin tests
+ * Some type tokens and dependency key, declared in java, used by kotlin tests for comparisons
  */
-public class JavaTypeTokens {
+public class JavaTokens {
   public static TypeToken<String> stringToken = TypeToken.of(String.class);
+  public static DependencyKey<String> stringKey = DependencyKey.of(stringToken);
+
   public static TypeToken<Integer> intToken = TypeToken.of(Integer.class);
+  public static DependencyKey<Integer> intKey = DependencyKey.of(intToken, new NamedAnnotationLiteral("intKey"));
 
   // maps to List<String> in kotlin
   public static TypeToken<List<? extends String>> stringListToken = new TypeToken<List<? extends String>>() {};
+  public static DependencyKey<List<? extends String>> stringListKey = DependencyKey.of(stringListToken);
 
   // maps to Map<String, Int> in kotlin
   public static TypeToken<Map<String, ? extends Integer>> stringIntMapToken = new TypeToken<Map<String, ? extends Integer>>() {};
+  public static DependencyKey<Map<String, ? extends Integer>> stringIntMapKey = DependencyKey.of(stringIntMapToken);
 
   // maps to MutableList<String> in kotlin
   public static TypeToken<List<String>> stringMutableListToken = new TypeToken<List<String>>() {};
+  public static DependencyKey<List<String>> stringMutableListKey = DependencyKey.of(stringMutableListToken);
 
   // maps to MutableMap<String, Integer> in kotlin
   public static TypeToken<Map<String, Integer>> stringIntMutableMapToken = new TypeToken<Map<String, Integer>>() {};
+  public static DependencyKey<Map<String, Integer>> stringIntMutableMapKey = DependencyKey.of(stringIntMutableMapToken);
 
   public static TypeToken<LinkedList<String>> stringLinkedListToken = new TypeToken<LinkedList<String>>() {};
+  public static DependencyKey<LinkedList<String>> stringLinkedListKey = DependencyKey.of(stringLinkedListToken);
+
   public static TypeToken<HashMap<String, Integer>> stringIntHashMapToken = new TypeToken<HashMap<String, Integer>>() {};
+  public static DependencyKey<HashMap<String, Integer>> stringIntHashMapKey = DependencyKey.of(stringIntHashMapToken);
 
   // type  token that is impossible to create/replicate in kotlin due to the `out` keyword
   // on the type variable in TestGenericKtInterface.

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/JavaTypeTokens.java
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/JavaTypeTokens.java
@@ -8,15 +8,28 @@ import java.util.List;
 import java.util.Map;
 
 /**
- *
+ * Some type tokens, declared in java, used by kotlin tests
  */
 public class JavaTypeTokens {
   public static TypeToken<String> stringToken = TypeToken.of(String.class);
   public static TypeToken<Integer> intToken = TypeToken.of(Integer.class);
 
-  public static TypeToken<List<String>> stringListToken = new TypeToken<List<String>>() {};
-  public static TypeToken<Map<String, Integer>> stringIntMapToken = new TypeToken<Map<String, Integer>>() {};
+  // maps to List<String> in kotlin
+  public static TypeToken<List<? extends String>> stringListToken = new TypeToken<List<? extends String>>() {};
+
+  // maps to Map<String, Int> in kotlin
+  public static TypeToken<Map<String, ? extends Integer>> stringIntMapToken = new TypeToken<Map<String, ? extends Integer>>() {};
+
+  // maps to MutableList<String> in kotlin
+  public static TypeToken<List<String>> stringMutableListToken = new TypeToken<List<String>>() {};
+
+  // maps to MutableMap<String, Integer> in kotlin
+  public static TypeToken<Map<String, Integer>> stringIntMutableMapToken = new TypeToken<Map<String, Integer>>() {};
 
   public static TypeToken<LinkedList<String>> stringLinkedListToken = new TypeToken<LinkedList<String>>() {};
   public static TypeToken<HashMap<String, Integer>> stringIntHashMapToken = new TypeToken<HashMap<String, Integer>>() {};
+
+  // type  token that is impossible to create/replicate in kotlin due to the `out` keyword
+  // on the type variable in TestGenericKtInterface.
+  public static TypeToken<TestGenericKtInterface<String>> genericInterfaceIllegalToken = new TypeToken<TestGenericKtInterface<String>>() {};
 }

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/JavaTypeTokens.java
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/JavaTypeTokens.java
@@ -1,0 +1,22 @@
+package com.episode6.hackit.mockspresso.reflect.testobject;
+
+import com.episode6.hackit.mockspresso.reflect.TypeToken;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ */
+public class JavaTypeTokens {
+  public static TypeToken<String> stringToken = TypeToken.of(String.class);
+  public static TypeToken<Integer> intToken = TypeToken.of(Integer.class);
+
+  public static TypeToken<List<String>> stringListToken = new TypeToken<List<String>>() {};
+  public static TypeToken<Map<String, Integer>> stringIntMapToken = new TypeToken<Map<String, Integer>>() {};
+
+  public static TypeToken<LinkedList<String>> stringLinkedListToken = new TypeToken<LinkedList<String>>() {};
+  public static TypeToken<HashMap<String, Integer>> stringIntHashMapToken = new TypeToken<HashMap<String, Integer>>() {};
+}

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestGenericKtInterface.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestGenericKtInterface.kt
@@ -1,0 +1,8 @@
+package com.episode6.hackit.mockspresso.reflect.testobject
+
+/**
+ *
+ */
+interface TestGenericKtInterface<out T> {
+  fun getSomething(): T
+}

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestGenericKtInterface.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestGenericKtInterface.kt
@@ -1,7 +1,9 @@
 package com.episode6.hackit.mockspresso.reflect.testobject
 
 /**
- *
+ * A test interface that uses the `out` keyword on its type variable.
+ * Used to display a java/kotlin interop issue when this interface is
+ * misused in java code.
  */
 interface TestGenericKtInterface<out T> {
   fun getSomething(): T

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestJavaObjectWithKtGeneric.java
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestJavaObjectWithKtGeneric.java
@@ -3,10 +3,12 @@ package com.episode6.hackit.mockspresso.reflect.testobject;
 import java.lang.reflect.Field;
 
 /**
- *
+ * Test object in java that mis-uses a kotlin interface.
  */
 public class TestJavaObjectWithKtGeneric {
 
+  // this field is basically a mis-use of the `TestGenericKtInterface` because of the `out` keyword on
+  // the type variable in that class. It should read `TestGenericKtInterface<? extends String>`
   public TestGenericKtInterface<String> genericIface;
 
   public Field getGenericIfaceField() {

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestJavaObjectWithKtGeneric.java
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/testobject/TestJavaObjectWithKtGeneric.java
@@ -1,0 +1,20 @@
+package com.episode6.hackit.mockspresso.reflect.testobject;
+
+import java.lang.reflect.Field;
+
+/**
+ *
+ */
+public class TestJavaObjectWithKtGeneric {
+
+  public TestGenericKtInterface<String> genericIface;
+
+  public Field getGenericIfaceField() {
+    try {
+      return getClass().getDeclaredField("genericIface");
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}


### PR DESCRIPTION
First of a batch of kotlin extension methods...

Adds inline kotlin methods to create `TypeToken`s and `DependencyKey`s using reified type parameters. Allows kotlin users to avoid some verbosity when creating them.