### PR TITLE
[Kotlin] Add extension method Builder.dependencyOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
  - Hide internal entry-point using kotlin `internal` visibility that was formerly public but not intended for public use.
  - Added kotlin extension methods using reified types to reduce verbosity
      - `typeToken<T>()`: Create a `TypeToken<T>`
-     - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier.  
+     - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier.
+     - `Builder.dependencyOf<T>(Annotation? = null, ()->T?)`: Alias for `Builder.dependencyProvider<T>()`.   
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
@@ -1,0 +1,11 @@
+package com.episode6.hackit.mockspresso
+
+import com.episode6.hackit.mockspresso.api.ObjectProvider
+import com.episode6.hackit.mockspresso.reflect.dependencyKey
+
+/**
+ * Kotlin extensions to mockspresso's api
+ */
+
+inline fun <reified T : Any> Mockspresso.Builder.dependencyOf(qualifier: Annotation? = null, noinline valueProvider: ()->T?): Mockspresso.Builder =
+    dependencyProvider(dependencyKey<T>(qualifier), ObjectProvider<T>(valueProvider))

--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
@@ -7,5 +7,14 @@ import com.episode6.hackit.mockspresso.reflect.dependencyKey
  * Kotlin extensions to mockspresso's api
  */
 
-inline fun <reified T : Any> Mockspresso.Builder.dependencyOf(qualifier: Annotation? = null, noinline valueProvider: ()->T?): Mockspresso.Builder =
-    dependencyProvider(dependencyKey<T>(qualifier), ObjectProvider<T>(valueProvider))
+/**
+ * Apply a specific instance of an object as a mockspresso dependency.
+ * Kotlin alias for [Mockspresso.Builder.dependencyProvider].
+ *
+ * @param qualifier Optional qualifier annotation that applies to the binding key of this dependency
+ * @param value Kotlin function/lambda that returns the dependency
+ */
+inline fun <reified T : Any> Mockspresso.Builder.dependencyOf(
+    qualifier: Annotation? = null,
+    noinline value: ()->T?
+): Mockspresso.Builder = dependencyProvider(dependencyKey<T>(qualifier), ObjectProvider<T>(value))

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -1,0 +1,75 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.annotation.Dependency
+import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.dependencyOf
+import com.episode6.hackit.mockspresso.mockito.MockitoPlugin
+import com.episode6.hackit.mockspresso.reflect.NamedAnnotationLiteral
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Named
+
+/**
+ * Testing kotlin extensions with mockito
+ */
+class MockitoKotlinExtensionTest {
+
+  private interface TestInterface
+  private class TestDependency : TestInterface
+  private class TestObjectWithConcrete(val testDep: TestDependency)
+  private class TestObjectWithInterface(val testDep: TestInterface)
+  private class TestObjectWithAnnotatedInterface(@Named("testing") val testDep: TestInterface)
+  private class TestResources {
+    @Dependency(bindAs = TestInterface::class) @field:Named("testing") val testDependency = TestDependency()
+  }
+
+  @get:Rule val mockspresso = BuildMockspresso.with()
+      .plugin(SimpleInjectMockspressoPlugin())
+      .plugin(MockitoPlugin())
+      .buildRule()
+
+  private val testDependency = TestDependency()
+
+  @Test fun testSimpleDependency() {
+    val testObject: TestObjectWithConcrete = mockspresso.buildUpon()
+        .dependencyOf { testDependency }
+        .build()
+        .create(TestObjectWithConcrete::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testDependency)
+  }
+
+  @Test fun testInterfaceDependency() {
+    val testObject: TestObjectWithInterface = mockspresso.buildUpon()
+        .dependencyOf<TestInterface> { testDependency }
+        .build()
+        .create(TestObjectWithInterface::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testDependency)
+  }
+
+  @Test fun testNamedInterfaceDependency() {
+    // we can't define an annotation literal in kotlin, but we can use one
+    // that is defined in java
+    val testObject: TestObjectWithAnnotatedInterface = mockspresso.buildUpon()
+        .dependencyOf<TestInterface>(qualifier = NamedAnnotationLiteral("testing")) { testDependency }
+        .build()
+        .create(TestObjectWithAnnotatedInterface::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testDependency)
+  }
+
+  @Test fun testNamedInterfaceDependencyWithTestResources() {
+    // we can still use field annotations on tests/test resources if we
+    // want to avoid annotation literals
+    val testResources = TestResources()
+    val testObject: TestObjectWithAnnotatedInterface = mockspresso.buildUpon()
+        .testResources(testResources)
+        .build()
+        .create(TestObjectWithAnnotatedInterface::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testResources.testDependency)
+  }
+}

--- a/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
+++ b/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
@@ -11,6 +11,8 @@ inline fun <reified T : Any> typeToken(): TypeToken<T> = object : TypeToken<T>()
 
 /**
  * Creates a [DependencyKey] for [T] with the provided qualifier annotation
+ *
+ * @param qualifier Optional qualifier annotation that applies to this key
  */
 inline fun <reified T : Any> dependencyKey(qualifier: Annotation? = null): DependencyKey<T> =
     DependencyKey.of<T>(typeToken<T>(), qualifier)


### PR DESCRIPTION
Adds an inline extension method to `Mockspresso.Builder` that uses a reified type param to reduce some verbosity when defining deps inline in kotlin. 

Was initially going to include two methods, one for direct obj references and one for providers. However the direct-reference version doesn't really add any value in a world where simple lambdas are so easy to create. It also would've require a different name and two different signatures (with and without the annotation) to maintain the same usage patterns as its java counterparts. So instead we opt for a single method that only accepts lambdas.