### PR TITLE
[Kotlin] Add extension methods to alias Builder.realObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
      - `typeToken<T>()`: Create a `TypeToken<T>`
      - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier.
      - `Builder.dependencyOf<T>(Annotation? = null, ()->T?)`: Alias for `Builder.dependencyProvider<T>()`.   
+     - `Builder.realImpl<BIND, IMPL>(Annotation? = null)`: Alias for `Builder.realObject(DependencyKey<BIND>, TypeToken<IMPL>)`
+     - `Builder.realClass<BIND_AND_IMPL>(Annotation? = null)`: Alias for `realImpl()` where `BIND` and `IMPL` are the same   
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
@@ -2,6 +2,7 @@ package com.episode6.hackit.mockspresso
 
 import com.episode6.hackit.mockspresso.api.ObjectProvider
 import com.episode6.hackit.mockspresso.reflect.dependencyKey
+import com.episode6.hackit.mockspresso.reflect.typeToken
 
 /**
  * Kotlin extensions to mockspresso's api
@@ -13,8 +14,31 @@ import com.episode6.hackit.mockspresso.reflect.dependencyKey
  *
  * @param qualifier Optional qualifier annotation that applies to the binding key of this dependency
  * @param value Kotlin function/lambda that returns the dependency
+ * @return the builder
  */
 inline fun <reified T : Any> Mockspresso.Builder.dependencyOf(
     qualifier: Annotation? = null,
     noinline value: ()->T?
 ): Mockspresso.Builder = dependencyProvider(dependencyKey<T>(qualifier), ObjectProvider<T>(value))
+
+/**
+ * Instruct mockspresso to create a real object (of type [IMPL]) to be bound using a dependency key of type [BIND].
+ * Kotlin alias for [Mockspresso.Builder.realObject]
+ *
+ * @param qualifier Optional qualifier annotation that applies to the binding key of this dependency
+ * @return the builder
+ */
+inline fun <reified BIND : Any, reified IMPL : BIND> Mockspresso.Builder.realImplOf(
+    qualifier: Annotation? = null
+): Mockspresso.Builder = realObject(dependencyKey<BIND>(qualifier), typeToken<IMPL>())
+
+/**
+ * Instruct mockspresso to create a real object and bind with a dependencyKey of its own concrete type
+ * Convenience method for [realImplOf] when both BIND and IMPL are the same type
+ *
+ * @param qualifier Optional qualifier annotation that applies to the binding key of this dependency
+ * @return the builder
+ */
+inline fun <reified BIND_AND_IMPL : Any> Mockspresso.Builder.realClassOf(
+    qualifier: Annotation? = null
+): Mockspresso.Builder = realImplOf<BIND_AND_IMPL, BIND_AND_IMPL>(qualifier)

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -9,6 +9,8 @@ import com.episode6.hackit.mockspresso.mockito.MockitoPlugin
 import com.episode6.hackit.mockspresso.realClassOf
 import com.episode6.hackit.mockspresso.realImplOf
 import com.episode6.hackit.mockspresso.reflect.NamedAnnotationLiteral
+import com.episode6.hackit.mockspresso.testing.isConcreteInstanceOf
+import com.episode6.hackit.mockspresso.testing.satisfies
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -89,11 +91,12 @@ class MockitoKotlinExtensionTest {
         .build()
         .create(OuterTestObjectWithConcreteObj::class.java)
 
-    outerObj.apply {
-      assertThat(testObj).isNot(mockCondition())
-      assertThat(testObj.javaClass).isEqualTo(TestObjectWithConcrete::class.java)
-      assertThat(testObj.testDep).isEqualTo(testDependency)
-    }
+    assertThat(outerObj.testObj)
+        .isNot(mockCondition())
+        .isConcreteInstanceOf<TestObjectWithConcrete>()
+        .satisfies {
+          assertThat(it.testDep).isEqualTo(testDependency)
+        }
   }
 
   @Test fun testRealImplOf() {
@@ -103,11 +106,12 @@ class MockitoKotlinExtensionTest {
         .build()
         .create(OuterTestObjectWithInterface::class.java)
 
-    outerObj.apply {
-      assertThat(testObj).isNot(mockCondition())
-      assertThat(testObj).isExactlyInstanceOf(TestObjectWithConcrete::class.java)
-      assertThat((testObj as TestObjectWithConcrete).testDep).isEqualTo(testDependency)
-    }
+    assertThat(outerObj.testObj)
+        .isNot(mockCondition())
+        .isConcreteInstanceOf<TestObjectWithConcrete>()
+        .satisfies {
+          assertThat(it.testDep).isEqualTo(testDependency)
+        }
   }
 
   @Test fun testAnnotatedRealImplOf() {
@@ -117,10 +121,11 @@ class MockitoKotlinExtensionTest {
         .build()
         .create(OuterTestObjectWithAnnotatedInterface::class.java)
 
-    outerObj.apply {
-      assertThat(testObj).isNot(mockCondition())
-      assertThat(testObj).isExactlyInstanceOf(TestObjectWithConcrete::class.java)
-      assertThat((testObj as TestObjectWithConcrete).testDep).isEqualTo(testDependency)
-    }
+    assertThat(outerObj.testObj)
+        .isNot(mockCondition())
+        .isConcreteInstanceOf<TestObjectWithConcrete>()
+        .satisfies {
+          assertThat(it.testDep).isEqualTo(testDependency)
+        }
   }
 }

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -16,13 +16,13 @@ import javax.inject.Named
  */
 class MockitoKotlinExtensionTest {
 
-  private interface TestInterface
-  private class TestDependency : TestInterface
+  private interface TestDependencyInterface
+  private class TestDependency : TestDependencyInterface
   private class TestObjectWithConcrete(val testDep: TestDependency)
-  private class TestObjectWithInterface(val testDep: TestInterface)
-  private class TestObjectWithAnnotatedInterface(@Named("testing") val testDep: TestInterface)
+  private class TestObjectWithInterface(val testDep: TestDependencyInterface)
+  private class TestObjectWithAnnotatedInterface(@Named("testing") val testDep: TestDependencyInterface)
   private class TestResources {
-    @Dependency(bindAs = TestInterface::class) @field:Named("testing") val testDependency = TestDependency()
+    @Dependency(bindAs = TestDependencyInterface::class) @field:Named("testing") val testDependency = TestDependency()
   }
 
   @get:Rule val mockspresso = BuildMockspresso.with()
@@ -43,7 +43,7 @@ class MockitoKotlinExtensionTest {
 
   @Test fun testInterfaceDependency() {
     val testObject: TestObjectWithInterface = mockspresso.buildUpon()
-        .dependencyOf<TestInterface> { testDependency }
+        .dependencyOf<TestDependencyInterface> { testDependency }
         .build()
         .create(TestObjectWithInterface::class.java)
 
@@ -54,7 +54,7 @@ class MockitoKotlinExtensionTest {
     // we can't define an annotation literal in kotlin, but we can use one
     // that is defined in java
     val testObject: TestObjectWithAnnotatedInterface = mockspresso.buildUpon()
-        .dependencyOf<TestInterface>(qualifier = NamedAnnotationLiteral("testing")) { testDependency }
+        .dependencyOf<TestDependencyInterface>(qualifier = NamedAnnotationLiteral("testing")) { testDependency }
         .build()
         .create(TestObjectWithAnnotatedInterface::class.java)
 

--- a/mockspresso-testing-shared/src/main/java/com/episode6/hackit/mockspresso/testing/TestExt.kt
+++ b/mockspresso-testing-shared/src/main/java/com/episode6/hackit/mockspresso/testing/TestExt.kt
@@ -1,0 +1,26 @@
+package com.episode6.hackit.mockspresso.testing
+
+import org.fest.assertions.api.ObjectAssert
+import org.fest.assertions.core.Condition
+
+/**
+ * Some extension methods to make testing with fest less verbose.
+ * I'd like to switch it up with assertJ but who has that kind of time.
+ */
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T : Any> ObjectAssert<*>.isConcreteInstanceOf(): ObjectAssert<T> =
+    isExactlyInstanceOf(T::class.java) as ObjectAssert<T>
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T : Any> ObjectAssert<*>.isCastableAs(): ObjectAssert<T> =
+    isInstanceOf(T::class.java) as ObjectAssert<T>
+
+fun <T : Any> ObjectAssert<T>.matches(condition: Condition<T>): ObjectAssert<T> = `is`(condition)
+
+fun <T : Any> ObjectAssert<T>.satisfies(block: (T) -> Unit): ObjectAssert<T> = matches(object : Condition<T>() {
+  override fun matches(value: T): Boolean {
+    block(value)
+    return true
+  }
+})


### PR DESCRIPTION
Adds inline extension methods to alias `Mockspresso.Builder.realObject` methods using kotlin reified types.

Since kotlin doesn't support optional type parameters, this required two distinct method names/signatures. 
- `Builder.realImpl<BIND, IMPL>()` is used when binding a concrete real object to a DI interface or abstract class
- `Builder.realClass<BIND_AND_IMPL>()` is used (for convenience) when binging a concrete real object as itself.