### PR TITLE
[BREAKING] Remove Builder.specialObjectMakers(List) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  - Annotate interfaces null/not null for kotlin compatibility
  - **BREAKING** Remove retrolambda and target Java 8
  - **BREAKING** Hide internal entry-point using kotlin `internal` visibility that was formerly public but not intended for public use.
+ - **BREAKING** Remove `Mockspresso.Builder.specialObjectMakers(List)` method. It's the only one of its kind and there is no good reason for it.
  - Added kotlin extension methods using reified types to reduce verbosity
      - `typeToken<T>()`: Create a `TypeToken<T>`
      - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier.

--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
@@ -8,8 +8,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 
-import java.util.List;
-
 /**
  * Main mockspresso interface
  */
@@ -182,16 +180,6 @@ public interface Mockspresso {
      * @return this
      */
     @NotNull Builder specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker);
-
-    /**
-     * Apply a list of {@link SpecialObjectMaker}s to this builder, which tells mockspresso how it should create
-     * object types that should not be mocked by default.
-     * @param specialObjectMakers The SpecialObjectMakers to apply
-     * @return this
-     *
-     * TODO: Signature of this method is wrong, should be generic should be '? extends SpecialObjectMaker'
-     */
-    @NotNull Builder specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers);
 
     /**
      * Apply a specific instance of an object as a mockspresso dependency.

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
@@ -4,9 +4,9 @@ import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import com.episode6.hackit.mockspresso.util.Preconditions;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import javax.inject.Provider;
 import java.util.HashSet;
 import java.util.Set;

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/DelayedMockspressoBuilder.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/DelayedMockspressoBuilder.java
@@ -5,12 +5,11 @@ import com.episode6.hackit.mockspresso.api.*;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 
-import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
-import java.util.List;
 
 /**
  * An implementation of {@link Mockspresso.Builder} that also acts as its own Mockspresso instance.
@@ -103,13 +102,6 @@ class DelayedMockspressoBuilder extends AbstractDelayedMockspresso implements Mo
   @Override
   public Builder specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker) {
     mBuilder.specialObjectMaker(specialObjectMaker);
-    return this;
-  }
-
-  @NotNull
-  @Override
-  public Builder specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers) {
-    mBuilder.specialObjectMakers(specialObjectMakers);
     return this;
   }
 

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoBuilderImpl.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoBuilderImpl.java
@@ -9,10 +9,10 @@ import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import com.episode6.hackit.mockspresso.util.CollectionUtil;
 import com.episode6.hackit.mockspresso.util.Preconditions;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 
-import org.jetbrains.annotations.Nullable;
 import javax.inject.Provider;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -148,13 +148,6 @@ class MockspressoBuilderImpl implements Mockspresso.Builder {
   @Override
   public Mockspresso.Builder specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker) {
     mSpecialObjectMakers.add(specialObjectMaker);
-    return this;
-  }
-
-  @NotNull
-  @Override
-  public Mockspresso.Builder specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers) {
-    mSpecialObjectMakers.addAll(specialObjectMakers);
     return this;
   }
 

--- a/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
+++ b/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
@@ -10,8 +10,6 @@ import org.junit.rules.TestRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
-import java.util.List;
-
 /**
  * Extend these 3 classes to create your own mockspresso extension
  * {@link AbstractMockspressoExtension}
@@ -250,13 +248,6 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
     @Override
     public BLDR specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker) {
       mDelegate.specialObjectMaker(specialObjectMaker);
-      return (BLDR) this;
-    }
-
-    @NotNull
-    @Override
-    public BLDR specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers) {
-      mDelegate.specialObjectMakers(specialObjectMakers);
       return (BLDR) this;
     }
 

--- a/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/MockspressoExtension.java
+++ b/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/MockspressoExtension.java
@@ -9,8 +9,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 
-import java.util.List;
-
 /**
  * Extend these 3 interfaces to build your own Mockspresso extension and own your api.
  * {@link MockspressoExtension}
@@ -87,9 +85,6 @@ public interface MockspressoExtension<BLDR extends MockspressoExtension.Builder>
 
     @Override
     @NotNull BLDR specialObjectMaker(@NotNull SpecialObjectMaker specialObjectMaker);
-
-    @Override
-    @NotNull BLDR specialObjectMakers(@NotNull List<SpecialObjectMaker> specialObjectMakers);
 
     @Override
     @NotNull <T, V extends T> BLDR dependency(@NotNull Class<T> clazz, @Nullable V value);

--- a/mockspresso-extend/src/test/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtensionTest.java
+++ b/mockspresso-extend/src/test/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtensionTest.java
@@ -207,12 +207,6 @@ public class AbstractMockspressoExtensionTest {
   }
 
   @Test
-  public void testMockspressoExtensionBuilder_specialObjectMakers() {
-    testMockspressoBuilder.specialObjectMakers(specialObjectMakers);
-    verify(mockspressoBuilder).specialObjectMakers(specialObjectMakers);
-  }
-
-  @Test
   public void testMockspressoExtensionBuilder_dep1() {
     testMockspressoBuilder.dependency(String.class, "hello");
     verify(mockspressoBuilder).dependency(String.class, "hello");


### PR DESCRIPTION
Removes a method from our `Mockspresso.Builder` api: `Mockspreso.Builder.specialObjectMakers(List<SpecialObjectMaker)`.

This "pluralized" method is the only one of its kind in the api and has no good reason to exist. It is technically a breaking change, but a very easy one to fix. If there is a need to "group" multiple special object makers together, its recommended to use a plugin instead.