### PR TITLE
[VERSION] Early prep for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-### v0.0.17 - unreleased
+### v0.1.0 - unreleased
  - Add kotlin support
  - Replace jsr305 with jetbrains annotations
  - Annotate interfaces null/not null for kotlin compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # ChangeLog
 
 ### v0.1.0 - unreleased
- - Add kotlin support
- - Replace jsr305 with jetbrains annotations
+ - Add kotlin support/dependencies too all modules
+ - **BREAKING** Replace jsr305 with jetbrains annotations
  - Annotate interfaces null/not null for kotlin compatibility
- - Remove retrolambda and target Java 8
- - Hide internal entry-point using kotlin `internal` visibility that was formerly public but not intended for public use.
+ - **BREAKING** Remove retrolambda and target Java 8
+ - **BREAKING** Hide internal entry-point using kotlin `internal` visibility that was formerly public but not intended for public use.
  - Added kotlin extension methods using reified types to reduce verbosity
      - `typeToken<T>()`: Create a `TypeToken<T>`
      - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.1.0 - unreleased
  - Add kotlin support/dependencies too all modules
- - **BREAKING** Replace jsr305 with jetbrains annotations
+ - **BREAKING** Replace jsr305 (`@Nullable`) with jetbrains annotations
  - Annotate interfaces null/not null for kotlin compatibility
  - **BREAKING** Remove retrolambda and target Java 8
  - **BREAKING** Hide internal entry-point using kotlin `internal` visibility that was formerly public but not intended for public use.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mockspresso
-An extensible auto-mocker for java, designed to simplify your unit tests. (now with PowerMock support!)
+An extensible auto-mocker for java, designed to simplify your unit tests.
+
+`It's like dependency injection for your tests.`
 
 ## What & Why?
 Testing code is a pain in the ass. Mockspresso was created with the simple idea that if tests are easier to write and break less often, developers will hate them less, and write more of them.
@@ -8,7 +10,12 @@ Mockspresso creates your objects for you, letting you drop the constructors from
 
 
 ## Version
-This doc describes mockspresso version `0.0.17-SNAPSHOT`
+#### Mockspresso is turning 0.1.0 soon! Kotlin Support!
+Mockspresso v0.1.0 will be bringing proper kotlin support, as it's now our primary focus. We're adding extension methods with reified types, so you should never have to manually deal with TypeTokens ever again.
+
+We are trying to avoid too many breaking api changes in this version, and will save those for the next major update. However there are some minor ones. Check the [ChangeLog](CHANGELOG.md) for details.
+
+This doc describes mockspresso version `0.1.0-SNAPSHOT`
 
 ## Installation
 There are 3 ways to setup mockspresso in your project.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Mockspresso creates your objects for you, letting you drop the constructors from
 
 
 ## Version
-#### Mockspresso is turning 0.1.0 soon! Kotlin Support!
-Mockspresso v0.1.0 will be bringing proper kotlin support, as it's now our primary focus. We're adding extension methods with reified types, so you should never have to manually deal with TypeTokens ever again.
+#### Mockspresso is turning 0.1.0 soon! With Kotlin support!
+Mockspresso v0.1.0 will be bringing proper kotlin support. We're adding extension methods to simplify mockspresso usage in kotlin, and making kotlin use-cases the primary focus of this project. 
 
 We are trying to avoid too many breaking api changes in this version, and will save those for the next major update. However there are some minor ones. Check the [ChangeLog](CHANGELOG.md) for details.
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,5 +13,5 @@ allprojects {
   }
 
   group = "com.episode6.hackit.mockspresso"
-  version = "0.0.17-SNAPSHOT"
+  version = "0.1.0-SNAPSHOT"
 }


### PR DESCRIPTION
We're going to release this new version as `v0.1.0`, since it bundles a whole mess of changes (a handful of breaking ones) & its focused on a major feature (kotlin support)

Updates the version & makes appropriate changes to changelog and readme.
Piggybacks:
- Highlight breaking changes in changelog
- Update top section of readme with a nice quote
- Add a readme blurb about the upcoming changes