### PR TITLE
[Kotlin] Add kotlin extensions for typed Mockspresso api methods

### DIFF
--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/MockspressoExt.kt
@@ -42,3 +42,33 @@ inline fun <reified BIND : Any, reified IMPL : BIND> Mockspresso.Builder.realImp
 inline fun <reified BIND_AND_IMPL : Any> Mockspresso.Builder.realClassOf(
     qualifier: Annotation? = null
 ): Mockspresso.Builder = realImplOf<BIND_AND_IMPL, BIND_AND_IMPL>(qualifier)
+
+/**
+ * Create a real object of type [T] injected with mockspresso dependencies.
+ *
+ * @return An instance of [T]
+ */
+inline fun <reified T : Any> Mockspresso.createNew(): T = create(typeToken<T>())
+
+/**
+ * Inject an existing object with mockspresso dependencies.
+ * Field and method injection will be performed (assuming the
+ * injector of this mockspresso instance supports it). Uses a reified
+ * type and includes a TypeToken in the method call, so will work with
+ * generics.
+ *
+ * @param instance The object to inject mocks/dependencies into.
+ */
+inline fun <reified T : Any> Mockspresso.injectType(
+    instance: T
+): Unit = inject(instance, typeToken<T>())
+
+/**
+ * Get a dependency (creating a new mock, if needed) from mockspresso.
+ * 
+ * @param qualifier The optional qualifier annotation for this object's
+ * [com.episode6.hackit.mockspresso.reflect.DependencyKey]
+ */
+inline fun <reified T : Any> Mockspresso.getDependencyOf(
+    qualifier: Annotation? = null
+): T? = getDependency(dependencyKey<T>(qualifier))

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -1,0 +1,110 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.annotation.Dependency
+import com.episode6.hackit.mockspresso.annotation.RealObject
+import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.createNew
+import com.episode6.hackit.mockspresso.getDependencyOf
+import com.episode6.hackit.mockspresso.injectType
+import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.mockito.MockitoPlugin
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+/**
+ *
+ */
+class MockitoKotlinExtensionTest {
+
+  private interface TestDependencyInterface
+  private class TestDependency : TestDependencyInterface
+
+  private class TestObject(val dep: TestDependencyInterface)
+
+  private class TestGeneric<T : Any> @Inject constructor() {
+    @Inject lateinit var dep: T
+  }
+
+  private class InjectTestResources {
+    @RealObject lateinit var testGeneric: TestGeneric<TestDependencyInterface>
+  }
+
+  @get:Rule val mockspresso = BuildMockspresso.with()
+      .plugin(SimpleInjectMockspressoPlugin())
+      .plugin(MockitoPlugin())
+      .buildRule()
+
+  @Dependency private val testDependency: TestDependencyInterface = TestDependency()
+
+  @RealObject private lateinit var testObject: TestObject
+
+
+  @Test fun testCreateConcrete() {
+    val testObject2: TestObject = mockspresso.createNew()
+
+    assertThat(testObject2)
+        .isNotNull
+        .isNot(mockCondition())
+        .isNotEqualTo(testObject)
+    assertThat(testObject2.dep)
+        .isEqualTo(testObject.dep)
+        .isEqualTo(testDependency)
+  }
+
+  @Test fun testCreateGeneric() {
+    InjectTestResources().apply {
+      val testObject2: TestGeneric<TestDependencyInterface> = mockspresso.buildUpon()
+          .plugin(JavaxInjectMockspressoPlugin())
+          .testResources(this)
+          .build()
+          .createNew()
+
+      assertThat(testObject2)
+          .isNotNull
+          .isNot(mockCondition())
+          .isNotEqualTo(testGeneric)
+      assertThat(testObject2.dep)
+          .isEqualTo(testGeneric.dep)
+          .isEqualTo(testDependency)
+    }
+  }
+
+  @Test fun testGetConcreteObject() {
+    val testObject2: TestObject = mockspresso.getDependencyOf()!!
+
+    assertThat(testObject2)
+        .isNotNull
+        .isNot(mockCondition())
+        .isEqualTo(testObject)
+  }
+
+  @Test fun testGetGenericObject() {
+    InjectTestResources().apply {
+      val testObject2: TestGeneric<TestDependencyInterface> = mockspresso.buildUpon()
+          .plugin(JavaxInjectMockspressoPlugin())
+          .testResources(this)
+          .build()
+          .getDependencyOf()!!
+
+      assertThat(testObject2)
+          .isNotNull
+          .isNot(mockCondition())
+          .isEqualTo(testGeneric)
+    }
+  }
+
+  @Test fun testGenericInjection() {
+    val testObject2 = TestGeneric<TestDependencyInterface>()
+    mockspresso.buildUpon()
+        .plugin(JavaxInjectMockspressoPlugin())
+        .build()
+        .injectType(testObject2)
+
+    assertThat(testObject2.dep)
+        .isEqualTo(testDependency)
+  }
+}


### PR DESCRIPTION
Adds the following kotlin extension methods (with reified types for less verbose usage)

`Mockspresso.createNew<T>(): T` -> `Mockspresso.create(TypeToken<T>)`
`Mockspresso.injectType<T>(T): Unit` -> `Mockspresso.inject(TypeToken<T>)`
`Mockspresso.getDependencyOf<T>(Annotation? = null): T?` -> `Mockspresso.getDependency(DependencyKey<T>)`