### PR TITLE
[Kotlin] Add extension methods for basic plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@
  - **BREAKING** Remove `Mockspresso.Builder.specialObjectMakers(List)` method. It's the only one of its kind and there is no good reason for it.
  - Added kotlin extension methods using reified types to reduce verbosity
      - `typeToken<T>()`: Create a `TypeToken<T>`
-     - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier.
-     - `Builder.dependencyOf<T>(Annotation? = null, ()->T?)`: Alias for `Builder.dependencyProvider<T>()`.   
+     - `dependencyKey<T>(Annotation? = null)`: Create a `DependencyKey<T>` with an optional qualifier
+     - `Builder.dependencyOf<T>(Annotation? = null, ()->T?)`: Alias for `Builder.dependencyProvider<T>()`   
      - `Builder.realImpl<BIND, IMPL>(Annotation? = null)`: Alias for `Builder.realObject(DependencyKey<BIND>, TypeToken<IMPL>)`
-     - `Builder.realClass<BIND_AND_IMPL>(Annotation? = null)`: Alias for `realImpl()` where `BIND` and `IMPL` are the same   
+     - `Builder.realClass<BIND_AND_IMPL>(Annotation? = null)`: Alias for `realImpl()` where `BIND` and `IMPL` are the same
+ - Added kotlin convenience extension methods for built in plugins
+     - `Builder.injectWithSimpleConfig()`: Applies the simple injection configuration plugin
+     - `Builder.injectWithJavaxConfig()`: Applies the Javax injection configuration plugin
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-basic-plugins/build.gradle
+++ b/mockspresso-basic-plugins/build.gradle
@@ -8,5 +8,6 @@ dependencies {
   testImplementation 'junit:junit'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.easytesting:fest-assert-core'
+  testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
 }
 

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
@@ -1,0 +1,22 @@
+package com.episode6.hackit.mockspresso.basic.plugin
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+
+/**
+ * Kotlin extensions for mockspresso's basic plugins
+ */
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.InjectionConfig] for simple creation of objects via
+ * their shortest constructor.
+ */
+fun Mockspresso.Builder.injectWithSimpleConfig(): Mockspresso.Builder = plugin(SimpleInjectMockspressoPlugin())
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.InjectionConfig] for javax.inject based object creation
+ * (looks for constructors, fields and methods annotated with @Inject).
+ * Also includes special object support for [javax.inject.Provider]s
+ */
+fun Mockspresso.Builder.injectWithJavaxConfig(): Mockspresso.Builder = plugin(JavaxInjectMockspressoPlugin())

--- a/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
+++ b/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
@@ -1,0 +1,31 @@
+package com.episode6.hackit.mockspresso.basic.plugin
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+import org.mockito.stubbing.Answer
+
+
+/**
+ * Tests [com.episode6.hackit.mockspresso.basic.plugin.BasicPluginsExtKt]
+ */
+class BasicPluginsExtTest {
+
+  val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
+
+  @Test fun testSimplePluginSourceOfTruth() {
+    builder.injectWithSimpleConfig()
+
+    verify(builder).plugin(any<SimpleInjectMockspressoPlugin>())
+  }
+
+  @Test fun testJavaxPluginSourceOfTruth() {
+    builder.injectWithJavaxConfig()
+
+    verify(builder).plugin(any<JavaxInjectMockspressoPlugin>())
+  }
+}

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
@@ -2,7 +2,7 @@ package com.episode6.hackit.mockspresso.mockito.integration
 
 import com.episode6.hackit.mockspresso.BuildMockspresso
 import com.episode6.hackit.mockspresso.annotation.Dependency
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
 import com.episode6.hackit.mockspresso.dependencyOf
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
 import com.episode6.hackit.mockspresso.mockito.MockitoPlugin
@@ -37,7 +37,7 @@ class MockitoKotlinBuilderExtensionTest {
   private class OuterTestObjectWithAnnotatedInterface(@Named("testing")  val testObj: TestObjectInterface)
 
   @get:Rule val mockspresso = BuildMockspresso.with()
-      .plugin(SimpleInjectMockspressoPlugin())
+      .injectWithSimpleConfig()
       .plugin(MockitoPlugin())
       .buildRule()
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -3,8 +3,8 @@ package com.episode6.hackit.mockspresso.mockito.integration
 import com.episode6.hackit.mockspresso.BuildMockspresso
 import com.episode6.hackit.mockspresso.annotation.Dependency
 import com.episode6.hackit.mockspresso.annotation.RealObject
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.injectWithJavaxConfig
+import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
 import com.episode6.hackit.mockspresso.createNew
 import com.episode6.hackit.mockspresso.getDependencyOf
 import com.episode6.hackit.mockspresso.injectType
@@ -34,7 +34,7 @@ class MockitoKotlinExtensionTest {
   }
 
   @get:Rule val mockspresso = BuildMockspresso.with()
-      .plugin(SimpleInjectMockspressoPlugin())
+      .injectWithSimpleConfig()
       .plugin(MockitoPlugin())
       .buildRule()
 
@@ -58,7 +58,7 @@ class MockitoKotlinExtensionTest {
   @Test fun testCreateGeneric() {
     InjectTestResources().apply {
       val testObject2: TestGeneric<TestDependencyInterface> = mockspresso.buildUpon()
-          .plugin(JavaxInjectMockspressoPlugin())
+          .injectWithJavaxConfig()
           .testResources(this)
           .build()
           .createNew()
@@ -85,7 +85,7 @@ class MockitoKotlinExtensionTest {
   @Test fun testGetGenericObject() {
     InjectTestResources().apply {
       val testObject2: TestGeneric<TestDependencyInterface> = mockspresso.buildUpon()
-          .plugin(JavaxInjectMockspressoPlugin())
+          .injectWithJavaxConfig()
           .testResources(this)
           .build()
           .getDependencyOf()!!
@@ -100,7 +100,7 @@ class MockitoKotlinExtensionTest {
   @Test fun testGenericInjection() {
     val testObject2 = TestGeneric<TestDependencyInterface>()
     mockspresso.buildUpon()
-        .plugin(JavaxInjectMockspressoPlugin())
+        .injectWithJavaxConfig()
         .build()
         .injectType(testObject2)
 


### PR DESCRIPTION
Add extension methods for mockspresso's basic plugins.
`Mockspresso.Builder.injectWithSimpleConfig()` and
`Mockspresso.Builder.injectWithJavaxConfig()`

Includes a new test dependency on mockito-kotlin