### PR TITLE
[Kotlin] Add extensions for mockito plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
  - Added kotlin convenience extension methods for built in plugins
      - `Builder.injectWithSimpleConfig()`: Applies the simple injection configuration plugin
      - `Builder.injectWithJavaxConfig()`: Applies the Javax injection configuration plugin
+     - `Builder.mockWithMockito()`: Applies the mockito mocker config
+     - `Builder.automaticFactories(vararg KClass<*>)`: Special object handling using `MockitoAutoFactoryMaker`
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-mockito/build.gradle
+++ b/mockspresso-mockito/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
   testImplementation 'junit:junit'
   testImplementation 'org.easytesting:fest-assert-core'
+  testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
 }
 
 test {

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
@@ -1,0 +1,29 @@
+package com.episode6.hackit.mockspresso.mockito
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import kotlin.reflect.KClass
+
+/**
+ * Kotlin extension methods for mockspresso's mockito plugins
+ */
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] to support mockito
+ */
+fun Mockspresso.Builder.mockWithMockito(): Mockspresso.Builder = plugin(MockitoPlugin())
+
+/**
+ * Applies special object handling for the provided factory classes. The
+ * applicable objects will be mocked by mockito, but with a default answer
+ * that returns objects from mockspresso's dependency map (similar to how
+ * the javax() injector automatically binds Providers, but applied to any
+ * factory class, including generics).
+ */
+fun Mockspresso.Builder.automaticFactories(vararg classes: Class<*>): Mockspresso.Builder =
+    specialObjectMaker(MockitoAutoFactoryMaker.create(*classes))
+
+/**
+ * Convenience function to call [automaticFactories] using kotlin KClasses instead of java Classes
+ */
+fun Mockspresso.Builder.automaticFactories(vararg classes: KClass<*>): Mockspresso.Builder =
+    automaticFactories(*classes.map { it.java }.toTypedArray())

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoKotlinMockingTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoKotlinMockingTest.kt
@@ -1,0 +1,44 @@
+package com.episode6.hackit.mockspresso.mockito
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.annotation.Dependency
+import com.episode6.hackit.mockspresso.annotation.RealObject
+import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
+import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.testing.matches
+import com.nhaarman.mockitokotlin2.mock
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import javax.inject.Named
+
+/**
+ * Test mocking using kotlin ext methods
+ */
+class MockitoKotlinMockingTest {
+
+  private interface TestDep1
+  private interface TestDep2
+  private interface TestDep3
+  private class TestObj(
+      val dep1: TestDep1,
+      @Named("dep2") val dep2: TestDep2,
+      val dep3: TestDep3)
+
+  @get:Rule val mockspresso = BuildMockspresso.with()
+      .injectWithSimpleConfig()
+      .mockWithMockito()
+      .buildRule()
+
+  @Mock private lateinit var dep1: TestDep1
+  @Dependency @field:Named("dep2") private val dep2: TestDep2 = mock()
+
+  @RealObject private lateinit var testObj: TestObj
+
+  @Test fun assertDepsAreMocks() {
+    assertThat(testObj.dep1).isEqualTo(dep1).matches(mockCondition())
+    assertThat(testObj.dep2).isEqualTo(dep2).matches(mockCondition())
+    assertThat(testObj.dep3).matches(mockCondition())
+  }
+}

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
@@ -1,0 +1,49 @@
+package com.episode6.hackit.mockspresso.mockito
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.reflect.dependencyKey
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Test
+import org.mockito.stubbing.Answer
+
+/**
+ * Tests [com.episode6.hackit.mockspresso.mockito.MockitoPluginsExtKt]
+ */
+class MockitoPluginsExtTest {
+
+  val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
+
+  @Test fun testMockPluginSourceOfTruth() {
+    builder.mockWithMockito()
+
+    verify(builder).plugin(any<MockitoPlugin>())
+  }
+
+  @Test fun testAutomaticFactorySourceOfTruthKotlin() {
+    builder.automaticFactories(String::class, Int::class)
+
+    argumentCaptor<MockitoAutoFactoryMaker> {
+      verify(builder).specialObjectMaker(capture())
+
+      assertThat(firstValue.canMakeObject(dependencyKey<String>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<Int>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<Long>())).isFalse
+    }
+  }
+
+  @Test fun testAutomaticFactorySourceOfTruthJava() {
+    builder.automaticFactories(String::class.java, Int::class.java)
+
+    argumentCaptor<MockitoAutoFactoryMaker> {
+      verify(builder).specialObjectMaker(capture())
+
+      assertThat(firstValue.canMakeObject(dependencyKey<String>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<Int>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<Long>())).isFalse
+    }
+  }
+}

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
@@ -9,6 +9,7 @@ import com.nhaarman.mockitokotlin2.verify
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.stubbing.Answer
+import javax.inject.Provider
 
 /**
  * Tests [com.episode6.hackit.mockspresso.mockito.MockitoPluginsExtKt]
@@ -24,25 +25,25 @@ class MockitoPluginsExtTest {
   }
 
   @Test fun testAutomaticFactorySourceOfTruthKotlin() {
-    builder.automaticFactories(String::class, Int::class)
+    builder.automaticFactories(Provider::class, HashMap::class)
 
     argumentCaptor<MockitoAutoFactoryMaker> {
       verify(builder).specialObjectMaker(capture())
 
-      assertThat(firstValue.canMakeObject(dependencyKey<String>())).isTrue
-      assertThat(firstValue.canMakeObject(dependencyKey<Int>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<Provider<String>>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<HashMap<String, Int>>())).isTrue
       assertThat(firstValue.canMakeObject(dependencyKey<Long>())).isFalse
     }
   }
 
   @Test fun testAutomaticFactorySourceOfTruthJava() {
-    builder.automaticFactories(String::class.java, Int::class.java)
+    builder.automaticFactories(Provider::class.java, HashMap::class.java)
 
     argumentCaptor<MockitoAutoFactoryMaker> {
       verify(builder).specialObjectMaker(capture())
 
-      assertThat(firstValue.canMakeObject(dependencyKey<String>())).isTrue
-      assertThat(firstValue.canMakeObject(dependencyKey<Int>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<Provider<String>>())).isTrue
+      assertThat(firstValue.canMakeObject(dependencyKey<HashMap<String, Int>>())).isTrue
       assertThat(firstValue.canMakeObject(dependencyKey<Long>())).isFalse
     }
   }

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/KotlinAutoFactoryTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/KotlinAutoFactoryTest.kt
@@ -1,0 +1,47 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.annotation.Dependency
+import com.episode6.hackit.mockspresso.annotation.RealObject
+import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
+import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.mockito.automaticFactories
+import com.episode6.hackit.mockspresso.mockito.mockWithMockito
+import com.episode6.hackit.mockspresso.testing.matches
+import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds
+import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGroundsFactory
+import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers
+import com.nhaarman.mockitokotlin2.mock
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Quick integration test for the automatic factories plugin.
+ */
+class KotlinAutoFactoryTest {
+
+  @get:Rule
+  val mockspresso = BuildMockspresso.with()
+      .injectWithSimpleConfig()
+      .mockWithMockito()
+      .automaticFactories(CoffeeGroundsFactory::class)
+      .buildRule()
+
+  // this mock should be returned by the CoffeeGroundsFactory that gets injected into mCoffeeMaker
+  @Dependency
+  val coffeeGrounds: CoffeeGrounds = mock()
+
+  @RealObject
+  lateinit var coffeeMaker: CoffeeMakers.GroundsFactoryCoffeeMaker
+
+  @Test
+  fun testCoffeeMaker() {
+    val coffee = coffeeMaker.brew()
+
+    assertThat(coffee.coffeeGrounds)
+        .isNotNull
+        .matches(mockCondition())
+        .isEqualTo(coffeeGrounds)
+  }
+}

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
@@ -5,7 +5,7 @@ import com.episode6.hackit.mockspresso.annotation.Dependency
 import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
 import com.episode6.hackit.mockspresso.dependencyOf
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
-import com.episode6.hackit.mockspresso.mockito.MockitoPlugin
+import com.episode6.hackit.mockspresso.mockito.mockWithMockito
 import com.episode6.hackit.mockspresso.realClassOf
 import com.episode6.hackit.mockspresso.realImplOf
 import com.episode6.hackit.mockspresso.reflect.NamedAnnotationLiteral
@@ -38,7 +38,7 @@ class MockitoKotlinBuilderExtensionTest {
 
   @get:Rule val mockspresso = BuildMockspresso.with()
       .injectWithSimpleConfig()
-      .plugin(MockitoPlugin())
+      .mockWithMockito()
       .buildRule()
 
   private val testDependency = TestDependency()

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -9,7 +9,7 @@ import com.episode6.hackit.mockspresso.createNew
 import com.episode6.hackit.mockspresso.getDependencyOf
 import com.episode6.hackit.mockspresso.injectType
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
-import com.episode6.hackit.mockspresso.mockito.MockitoPlugin
+import com.episode6.hackit.mockspresso.mockito.mockWithMockito
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -35,7 +35,7 @@ class MockitoKotlinExtensionTest {
 
   @get:Rule val mockspresso = BuildMockspresso.with()
       .injectWithSimpleConfig()
-      .plugin(MockitoPlugin())
+      .mockWithMockito()
       .buildRule()
 
   @Dependency private val testDependency: TestDependencyInterface = TestDependency()


### PR DESCRIPTION
Adds kotlin convenience methods to apply the mockspresso plugins from the `mockspresso-mockito` module.

`Mockspresso.Builder.mockWithMockito()`,
`Mockspresso.Builder.automaticFactories(vararg Class<*>)` and
`Mockspresso.Builder.automaticFactories(vararg KClass<*>)`

We purposefully did not add a version of `automaticFactory` with a reified type, because it wouldn't actually work as expected. In all the other methods where we're used reified types, we create TypeToken from them under the hood. But the automatic factory maker isn't quite that smart at the moment, and just uses `Class<?>`s as identifiers at the moment. I.e. `automaticFactory<Provider<String>>` would actually create handle all `Provider`s.

Making a note of this for a future update, but won't make it in to v0.1.0 