### PR TITLE
[Kotlin] Rename inject/mock extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
      - `Builder.realImpl<BIND, IMPL>(Annotation? = null)`: Alias for `Builder.realObject(DependencyKey<BIND>, TypeToken<IMPL>)`
      - `Builder.realClass<BIND_AND_IMPL>(Annotation? = null)`: Alias for `realImpl()` where `BIND` and `IMPL` are the same
  - Added kotlin convenience extension methods for built in plugins
-     - `Builder.injectWithSimpleConfig()`: Applies the simple injection configuration plugin
-     - `Builder.injectWithJavaxConfig()`: Applies the Javax injection configuration plugin
-     - `Builder.mockWithMockito()`: Applies the mockito mocker config
+     - `Builder.injectBySimpleConfig()`: Applies the simple injection configuration plugin
+     - `Builder.injectByJavaxConfig()`: Applies the Javax injection configuration plugin
+     - `Builder.mocksByMockito()`: Applies the mockito mocker config
      - `Builder.automaticFactories(vararg KClass<*>)`: Special object handling using `MockitoAutoFactoryMaker`
 
 ### v0.0.16 - March 24th, 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
  - Added kotlin convenience extension methods for built in plugins
      - `Builder.injectBySimpleConfig()`: Applies the simple injection configuration plugin
      - `Builder.injectByJavaxConfig()`: Applies the Javax injection configuration plugin
-     - `Builder.mocksByMockito()`: Applies the mockito mocker config
+     - `Builder.mockByMockito()`: Applies the mockito mocker config
      - `Builder.automaticFactories(vararg KClass<*>)`: Special object handling using `MockitoAutoFactoryMaker`
 
 ### v0.0.16 - March 24th, 2019

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
@@ -12,11 +12,11 @@ import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspres
  * Applies the [com.episode6.hackit.mockspresso.api.InjectionConfig] for simple creation of objects via
  * their shortest constructor.
  */
-fun Mockspresso.Builder.injectWithSimpleConfig(): Mockspresso.Builder = plugin(SimpleInjectMockspressoPlugin())
+fun Mockspresso.Builder.injectBySimpleConfig(): Mockspresso.Builder = plugin(SimpleInjectMockspressoPlugin())
 
 /**
  * Applies the [com.episode6.hackit.mockspresso.api.InjectionConfig] for javax.inject based object creation
  * (looks for constructors, fields and methods annotated with @Inject).
  * Also includes special object support for [javax.inject.Provider]s
  */
-fun Mockspresso.Builder.injectWithJavaxConfig(): Mockspresso.Builder = plugin(JavaxInjectMockspressoPlugin())
+fun Mockspresso.Builder.injectByJavaxConfig(): Mockspresso.Builder = plugin(JavaxInjectMockspressoPlugin())

--- a/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
+++ b/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
@@ -18,13 +18,13 @@ class BasicPluginsExtTest {
   val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
 
   @Test fun testSimplePluginSourceOfTruth() {
-    builder.injectWithSimpleConfig()
+    builder.injectBySimpleConfig()
 
     verify(builder).plugin(any<SimpleInjectMockspressoPlugin>())
   }
 
   @Test fun testJavaxPluginSourceOfTruth() {
-    builder.injectWithJavaxConfig()
+    builder.injectByJavaxConfig()
 
     verify(builder).plugin(any<JavaxInjectMockspressoPlugin>())
   }

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
 /**
  * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] to support mockito
  */
-fun Mockspresso.Builder.mockWithMockito(): Mockspresso.Builder = plugin(MockitoPlugin())
+fun Mockspresso.Builder.mocksByMockito(): Mockspresso.Builder = plugin(MockitoPlugin())
 
 /**
  * Applies special object handling for the provided factory classes. The

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KClass
 /**
  * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] to support mockito
  */
-fun Mockspresso.Builder.mocksByMockito(): Mockspresso.Builder = plugin(MockitoPlugin())
+fun Mockspresso.Builder.mockByMockito(): Mockspresso.Builder = plugin(MockitoPlugin())
 
 /**
  * Applies special object handling for the provided factory classes. The

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoKotlinMockingTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoKotlinMockingTest.kt
@@ -28,7 +28,7 @@ class MockitoKotlinMockingTest {
 
   @get:Rule val mockspresso = BuildMockspresso.with()
       .injectBySimpleConfig()
-      .mocksByMockito()
+      .mockByMockito()
       .buildRule()
 
   @Mock private lateinit var dep1: TestDep1

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoKotlinMockingTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoKotlinMockingTest.kt
@@ -3,7 +3,7 @@ package com.episode6.hackit.mockspresso.mockito
 import com.episode6.hackit.mockspresso.BuildMockspresso
 import com.episode6.hackit.mockspresso.annotation.Dependency
 import com.episode6.hackit.mockspresso.annotation.RealObject
-import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
 import com.episode6.hackit.mockspresso.testing.matches
 import com.nhaarman.mockitokotlin2.mock
@@ -27,8 +27,8 @@ class MockitoKotlinMockingTest {
       val dep3: TestDep3)
 
   @get:Rule val mockspresso = BuildMockspresso.with()
-      .injectWithSimpleConfig()
-      .mockWithMockito()
+      .injectBySimpleConfig()
+      .mocksByMockito()
       .buildRule()
 
   @Mock private lateinit var dep1: TestDep1

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
@@ -19,7 +19,7 @@ class MockitoPluginsExtTest {
   val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
 
   @Test fun testMockPluginSourceOfTruth() {
-    builder.mocksByMockito()
+    builder.mockByMockito()
 
     verify(builder).plugin(any<MockitoPlugin>())
   }

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
@@ -19,7 +19,7 @@ class MockitoPluginsExtTest {
   val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
 
   @Test fun testMockPluginSourceOfTruth() {
-    builder.mockWithMockito()
+    builder.mocksByMockito()
 
     verify(builder).plugin(any<MockitoPlugin>())
   }

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/KotlinAutoFactoryTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/KotlinAutoFactoryTest.kt
@@ -6,7 +6,7 @@ import com.episode6.hackit.mockspresso.annotation.RealObject
 import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
 import com.episode6.hackit.mockspresso.mockito.automaticFactories
-import com.episode6.hackit.mockspresso.mockito.mocksByMockito
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
 import com.episode6.hackit.mockspresso.testing.matches
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGroundsFactory
@@ -24,7 +24,7 @@ class KotlinAutoFactoryTest {
   @get:Rule
   val mockspresso = BuildMockspresso.with()
       .injectBySimpleConfig()
-      .mocksByMockito()
+      .mockByMockito()
       .automaticFactories(CoffeeGroundsFactory::class)
       .buildRule()
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/KotlinAutoFactoryTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/KotlinAutoFactoryTest.kt
@@ -3,10 +3,10 @@ package com.episode6.hackit.mockspresso.mockito.integration
 import com.episode6.hackit.mockspresso.BuildMockspresso
 import com.episode6.hackit.mockspresso.annotation.Dependency
 import com.episode6.hackit.mockspresso.annotation.RealObject
-import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
 import com.episode6.hackit.mockspresso.mockito.automaticFactories
-import com.episode6.hackit.mockspresso.mockito.mockWithMockito
+import com.episode6.hackit.mockspresso.mockito.mocksByMockito
 import com.episode6.hackit.mockspresso.testing.matches
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGroundsFactory
@@ -23,8 +23,8 @@ class KotlinAutoFactoryTest {
 
   @get:Rule
   val mockspresso = BuildMockspresso.with()
-      .injectWithSimpleConfig()
-      .mockWithMockito()
+      .injectBySimpleConfig()
+      .mocksByMockito()
       .automaticFactories(CoffeeGroundsFactory::class)
       .buildRule()
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
@@ -5,7 +5,7 @@ import com.episode6.hackit.mockspresso.annotation.Dependency
 import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
 import com.episode6.hackit.mockspresso.dependencyOf
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
-import com.episode6.hackit.mockspresso.mockito.mocksByMockito
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
 import com.episode6.hackit.mockspresso.realClassOf
 import com.episode6.hackit.mockspresso.realImplOf
 import com.episode6.hackit.mockspresso.reflect.NamedAnnotationLiteral
@@ -38,7 +38,7 @@ class MockitoKotlinBuilderExtensionTest {
 
   @get:Rule val mockspresso = BuildMockspresso.with()
       .injectBySimpleConfig()
-      .mocksByMockito()
+      .mockByMockito()
       .buildRule()
 
   private val testDependency = TestDependency()

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinBuilderExtensionTest.kt
@@ -2,10 +2,10 @@ package com.episode6.hackit.mockspresso.mockito.integration
 
 import com.episode6.hackit.mockspresso.BuildMockspresso
 import com.episode6.hackit.mockspresso.annotation.Dependency
-import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
 import com.episode6.hackit.mockspresso.dependencyOf
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
-import com.episode6.hackit.mockspresso.mockito.mockWithMockito
+import com.episode6.hackit.mockspresso.mockito.mocksByMockito
 import com.episode6.hackit.mockspresso.realClassOf
 import com.episode6.hackit.mockspresso.realImplOf
 import com.episode6.hackit.mockspresso.reflect.NamedAnnotationLiteral
@@ -37,8 +37,8 @@ class MockitoKotlinBuilderExtensionTest {
   private class OuterTestObjectWithAnnotatedInterface(@Named("testing")  val testObj: TestObjectInterface)
 
   @get:Rule val mockspresso = BuildMockspresso.with()
-      .injectWithSimpleConfig()
-      .mockWithMockito()
+      .injectBySimpleConfig()
+      .mocksByMockito()
       .buildRule()
 
   private val testDependency = TestDependency()

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -3,13 +3,13 @@ package com.episode6.hackit.mockspresso.mockito.integration
 import com.episode6.hackit.mockspresso.BuildMockspresso
 import com.episode6.hackit.mockspresso.annotation.Dependency
 import com.episode6.hackit.mockspresso.annotation.RealObject
-import com.episode6.hackit.mockspresso.basic.plugin.injectWithJavaxConfig
-import com.episode6.hackit.mockspresso.basic.plugin.injectWithSimpleConfig
+import com.episode6.hackit.mockspresso.basic.plugin.injectByJavaxConfig
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
 import com.episode6.hackit.mockspresso.createNew
 import com.episode6.hackit.mockspresso.getDependencyOf
 import com.episode6.hackit.mockspresso.injectType
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
-import com.episode6.hackit.mockspresso.mockito.mockWithMockito
+import com.episode6.hackit.mockspresso.mockito.mocksByMockito
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -34,8 +34,8 @@ class MockitoKotlinExtensionTest {
   }
 
   @get:Rule val mockspresso = BuildMockspresso.with()
-      .injectWithSimpleConfig()
-      .mockWithMockito()
+      .injectBySimpleConfig()
+      .mocksByMockito()
       .buildRule()
 
   @Dependency private val testDependency: TestDependencyInterface = TestDependency()
@@ -58,7 +58,7 @@ class MockitoKotlinExtensionTest {
   @Test fun testCreateGeneric() {
     InjectTestResources().apply {
       val testObject2: TestGeneric<TestDependencyInterface> = mockspresso.buildUpon()
-          .injectWithJavaxConfig()
+          .injectByJavaxConfig()
           .testResources(this)
           .build()
           .createNew()
@@ -85,7 +85,7 @@ class MockitoKotlinExtensionTest {
   @Test fun testGetGenericObject() {
     InjectTestResources().apply {
       val testObject2: TestGeneric<TestDependencyInterface> = mockspresso.buildUpon()
-          .injectWithJavaxConfig()
+          .injectByJavaxConfig()
           .testResources(this)
           .build()
           .getDependencyOf()!!
@@ -100,7 +100,7 @@ class MockitoKotlinExtensionTest {
   @Test fun testGenericInjection() {
     val testObject2 = TestGeneric<TestDependencyInterface>()
     mockspresso.buildUpon()
-        .injectWithJavaxConfig()
+        .injectByJavaxConfig()
         .build()
         .injectType(testObject2)
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinExtensionTest.kt
@@ -9,7 +9,7 @@ import com.episode6.hackit.mockspresso.createNew
 import com.episode6.hackit.mockspresso.getDependencyOf
 import com.episode6.hackit.mockspresso.injectType
 import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
-import com.episode6.hackit.mockspresso.mockito.mocksByMockito
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -35,7 +35,7 @@ class MockitoKotlinExtensionTest {
 
   @get:Rule val mockspresso = BuildMockspresso.with()
       .injectBySimpleConfig()
-      .mocksByMockito()
+      .mockByMockito()
       .buildRule()
 
   @Dependency private val testDependency: TestDependencyInterface = TestDependency()


### PR DESCRIPTION
I'm not happy with the way our new extension methods read when prefixed with `BuildMockspresso.with()`

This PR renames 3 of our methods to avoid the word `with`.

```
BuildMockspresso.with()
    .injectBySimpleConfig()
    .injectByJavaxConfig()
    .mockByMockito()
```