### PR TITLE
[Kotlin] Mark new plugin extension methods as JvmSynthetic

### DIFF
--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
@@ -12,6 +12,7 @@ import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspres
  * Applies the [com.episode6.hackit.mockspresso.api.InjectionConfig] for simple creation of objects via
  * their shortest constructor.
  */
+@JvmSynthetic
 fun Mockspresso.Builder.injectBySimpleConfig(): Mockspresso.Builder = plugin(SimpleInjectMockspressoPlugin())
 
 /**
@@ -19,4 +20,5 @@ fun Mockspresso.Builder.injectBySimpleConfig(): Mockspresso.Builder = plugin(Sim
  * (looks for constructors, fields and methods annotated with @Inject).
  * Also includes special object support for [javax.inject.Provider]s
  */
+@JvmSynthetic
 fun Mockspresso.Builder.injectByJavaxConfig(): Mockspresso.Builder = plugin(JavaxInjectMockspressoPlugin())

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
@@ -10,6 +10,7 @@ import kotlin.reflect.KClass
 /**
  * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] to support mockito
  */
+@JvmSynthetic
 fun Mockspresso.Builder.mockByMockito(): Mockspresso.Builder = plugin(MockitoPlugin())
 
 /**
@@ -19,11 +20,13 @@ fun Mockspresso.Builder.mockByMockito(): Mockspresso.Builder = plugin(MockitoPlu
  * the javax() injector automatically binds Providers, but applied to any
  * factory class, including generics).
  */
+@JvmSynthetic
 fun Mockspresso.Builder.automaticFactories(vararg classes: Class<*>): Mockspresso.Builder =
     specialObjectMaker(MockitoAutoFactoryMaker.create(*classes))
 
 /**
  * Convenience function to call [automaticFactories] using kotlin KClasses instead of java Classes
  */
+@JvmSynthetic
 fun Mockspresso.Builder.automaticFactories(vararg classes: KClass<*>): Mockspresso.Builder =
     automaticFactories(*classes.map { it.java }.toTypedArray())


### PR DESCRIPTION
Our new kotlin extension methods are not going to be helpful to java callers and may be a little confusing, so here we're marking them as `@JvmSynthetic` to hide them from java sources.

We don't need to mark the extensions in `:mockspresso-api` this way because they are all `inline` functions (which are naturally not call-callable from java code)