### PR TITLE
[Kotlin] Add extension method to apply dagger plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
  - Added kotlin convenience extension methods for built in plugins
      - `Builder.injectBySimpleConfig()`: Applies the simple injection configuration plugin
      - `Builder.injectByJavaxConfig()`: Applies the Javax injection configuration plugin
+     - `Builder.injectByDaggerConfig()`: Applies the dagger injection configuration plugin
      - `Builder.mockByMockito()`: Applies the mockito mocker config
      - `Builder.automaticFactories(vararg KClass<*>)`: Special object handling using `MockitoAutoFactoryMaker`
 

--- a/mockspresso-dagger/build.gradle
+++ b/mockspresso-dagger/build.gradle
@@ -14,5 +14,6 @@ dependencies {
   testImplementation 'com.google.dagger:dagger'
   testImplementation 'junit:junit'
   testImplementation 'org.easytesting:fest-assert-core'
+  testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
 }
 

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
@@ -1,0 +1,14 @@
+package com.episode6.hackit.mockspresso.dagger
+
+import com.episode6.hackit.mockspresso.Mockspresso
+
+/**
+ * Kotlin extension methods for mockspresso's Dagger plugins
+ */
+
+/**
+ * Applies an [InjectionConfig] for dagger. This is the same as injectByJavaxConfig()
+ * with additional support for dagger's Lazy interface.
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.injectByDaggerConfig(): Mockspresso.Builder = plugin(DaggerMockspressoPlugin())

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -1,0 +1,23 @@
+package com.episode6.hackit.mockspresso.dagger
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+import org.mockito.stubbing.Answer
+
+/**
+ * Tests [com.episode6.hackit.mockspresso.dagger.DaggerPluginsExtKt]
+ */
+class DaggerPluginsExtTest {
+
+  val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
+
+  @Test
+  fun testSimplePluginSourceOfTruth() {
+    builder.injectByDaggerConfig()
+
+    verify(builder).plugin(any<DaggerMockspressoPlugin>())
+  }
+}


### PR DESCRIPTION
Adds extension method `Mockspresso.Builder.injectByDaggerConfig()` to `:mockspresso-dagger`.