### PR TITLE
[Kotlin] Add extension method for mockByEasyMock()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
      - **:mockspresso-mockito** module
      - `Builder.mockByMockito()`: Applies the mockito mocker config
      - `Builder.automaticFactories(vararg KClass<*>)`: Special object handling using MockitoAutoFactoryMaker
+     - **:mockspresso-easymock** module
+     - `Builder.mockByEasyMock()`: Applies the easy mock mocker config
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
@@ -1,0 +1,13 @@
+package com.episode6.hackit.mockspresso.easymock
+
+import com.episode6.hackit.mockspresso.Mockspresso
+
+/**
+ * Kotlin extension methods for mockspresso's EasyMock plugins
+ */
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] to support EasyMock
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.mockByEasyMock(): Mockspresso.Builder = plugin(EasyMockPlugin())

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExtTest.kt
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExtTest.kt
@@ -1,0 +1,34 @@
+package com.episode6.hackit.mockspresso.easymock
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import org.easymock.EasyMock.*
+import org.easymock.EasyMockSupport
+import org.easymock.Mock
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests [com.episode6.hackit.mockspresso.easymock.EasyMockPluginsExtKt]
+ */
+class EasyMockPluginsExtTest {
+
+  @Mock
+  lateinit var builder: Mockspresso.Builder
+
+  @Before fun setup() {
+    EasyMockSupport.injectMocks(this)
+  }
+
+  @Test fun testEasyMockExtensionSourceOfTruth() {
+    expect(builder.plugin(anyObject(EasyMockPlugin::class.java))).andReturn(builder)
+    replay(builder)
+
+    val result = builder.mockByEasyMock()
+
+    verify(builder)
+    assertThat(result)
+        .isNotNull
+        .isEqualTo(builder)
+  }
+}

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/EasyMockKotlinBuilderExtensionTest.kt
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/EasyMockKotlinBuilderExtensionTest.kt
@@ -1,0 +1,131 @@
+package com.episode6.hackit.mockspresso.easymock.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.annotation.Dependency
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
+import com.episode6.hackit.mockspresso.dependencyOf
+import com.episode6.hackit.mockspresso.easymock.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.easymock.mockByEasyMock
+import com.episode6.hackit.mockspresso.realClassOf
+import com.episode6.hackit.mockspresso.realImplOf
+import com.episode6.hackit.mockspresso.reflect.NamedAnnotationLiteral
+import com.episode6.hackit.mockspresso.testing.isConcreteInstanceOf
+import com.episode6.hackit.mockspresso.testing.satisfies
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Named
+
+/**
+ * Testing kotlin extensions to [com.episode6.hackit.mockspresso.Mockspresso.Builder] with easymock
+ */
+class EasyMockKotlinBuilderExtensionTest {
+
+  private interface TestDependencyInterface
+  private interface TestObjectInterface
+  private class TestDependency : TestDependencyInterface
+
+  private class TestObjectWithConcrete(val testDep: TestDependency) : TestObjectInterface
+  private class TestObjectWithInterface(val testDep: TestDependencyInterface)
+  private class TestObjectWithAnnotatedInterface(@Named("testing") val testDep: TestDependencyInterface)
+  private class TestResources {
+    @Dependency(bindAs = TestDependencyInterface::class) @field:Named("testing") val testDependency = TestDependency()
+  }
+
+  private class OuterTestObjectWithConcreteObj(val testObj: TestObjectWithConcrete)
+  private class OuterTestObjectWithInterface(val testObj: TestObjectInterface)
+  private class OuterTestObjectWithAnnotatedInterface(@Named("testing")  val testObj: TestObjectInterface)
+
+  @get:Rule val mockspresso = BuildMockspresso.with()
+      .injectBySimpleConfig()
+      .mockByEasyMock()
+      .buildRule()
+
+  private val testDependency = TestDependency()
+
+  @Test fun testSimpleDependency() {
+    val testObject: TestObjectWithConcrete = mockspresso.buildUpon()
+        .dependencyOf { testDependency }
+        .build()
+        .create(TestObjectWithConcrete::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testDependency)
+  }
+
+  @Test fun testInterfaceDependency() {
+    val testObject: TestObjectWithInterface = mockspresso.buildUpon()
+        .dependencyOf<TestDependencyInterface> { testDependency }
+        .build()
+        .create(TestObjectWithInterface::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testDependency)
+  }
+
+  @Test fun testNamedInterfaceDependency() {
+    // we can't define an annotation literal in kotlin, but we can use one
+    // that is defined in java
+    val testObject: TestObjectWithAnnotatedInterface = mockspresso.buildUpon()
+        .dependencyOf<TestDependencyInterface>(qualifier = NamedAnnotationLiteral("testing")) { testDependency }
+        .build()
+        .create(TestObjectWithAnnotatedInterface::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testDependency)
+  }
+
+  @Test fun testNamedInterfaceDependencyWithTestResources() {
+    // we can still use field annotations on tests/test resources if we
+    // want to avoid annotation literals
+    val testResources = TestResources()
+    val testObject: TestObjectWithAnnotatedInterface = mockspresso.buildUpon()
+        .testResources(testResources)
+        .build()
+        .create(TestObjectWithAnnotatedInterface::class.java)
+
+    assertThat(testObject.testDep).isEqualTo(testResources.testDependency)
+  }
+
+  @Test fun testRealClassOf() {
+    val outerObj: OuterTestObjectWithConcreteObj = mockspresso.buildUpon()
+        .realClassOf<TestObjectWithConcrete>()
+        .dependencyOf { testDependency }
+        .build()
+        .create(OuterTestObjectWithConcreteObj::class.java)
+
+    assertThat(outerObj.testObj)
+        .isNot(mockCondition())
+        .isConcreteInstanceOf<TestObjectWithConcrete>()
+        .satisfies {
+          assertThat(it.testDep).isEqualTo(testDependency)
+        }
+  }
+
+  @Test fun testRealImplOf() {
+    val outerObj: OuterTestObjectWithInterface = mockspresso.buildUpon()
+        .realImplOf<TestObjectInterface, TestObjectWithConcrete>()
+        .dependencyOf { testDependency }
+        .build()
+        .create(OuterTestObjectWithInterface::class.java)
+
+    assertThat(outerObj.testObj)
+        .isNot(mockCondition())
+        .isConcreteInstanceOf<TestObjectWithConcrete>()
+        .satisfies {
+          assertThat(it.testDep).isEqualTo(testDependency)
+        }
+  }
+
+  @Test fun testAnnotatedRealImplOf() {
+    val outerObj: OuterTestObjectWithAnnotatedInterface = mockspresso.buildUpon()
+        .realImplOf<TestObjectInterface, TestObjectWithConcrete>(qualifier = NamedAnnotationLiteral("testing"))
+        .dependencyOf { testDependency }
+        .build()
+        .create(OuterTestObjectWithAnnotatedInterface::class.java)
+
+    assertThat(outerObj.testObj)
+        .isNot(mockCondition())
+        .isConcreteInstanceOf<TestObjectWithConcrete>()
+        .satisfies {
+          assertThat(it.testDep).isEqualTo(testDependency)
+        }
+  }
+}

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/EasyMockKotlinExtensionTest.kt
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/EasyMockKotlinExtensionTest.kt
@@ -1,4 +1,4 @@
-package com.episode6.hackit.mockspresso.mockito.integration
+package com.episode6.hackit.mockspresso.easymock.integration
 
 import com.episode6.hackit.mockspresso.BuildMockspresso
 import com.episode6.hackit.mockspresso.annotation.Dependency
@@ -6,19 +6,19 @@ import com.episode6.hackit.mockspresso.annotation.RealObject
 import com.episode6.hackit.mockspresso.basic.plugin.injectByJavaxConfig
 import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
 import com.episode6.hackit.mockspresso.createNew
+import com.episode6.hackit.mockspresso.easymock.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.easymock.mockByEasyMock
 import com.episode6.hackit.mockspresso.getDependencyOf
 import com.episode6.hackit.mockspresso.injectType
-import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
-import com.episode6.hackit.mockspresso.mockito.mockByMockito
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
 
 /**
- * Testing kotlin extensions to [com.episode6.hackit.mockspresso.Mockspresso] with mockito
+ * Testing kotlin extensions to [com.episode6.hackit.mockspresso.Mockspresso] with easymock
  */
-class MockitoKotlinExtensionTest {
+class EasyMockKotlinExtensionTest {
 
   private interface TestDependencyInterface
   private class TestDependency : TestDependencyInterface
@@ -35,7 +35,7 @@ class MockitoKotlinExtensionTest {
 
   @get:Rule val mockspresso = BuildMockspresso.with()
       .injectBySimpleConfig()
-      .mockByMockito()
+      .mockByEasyMock()
       .buildRule()
 
   @Dependency private val testDependency: TestDependencyInterface = TestDependency()

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/EasyMockKotlinMockingTest.kt
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/EasyMockKotlinMockingTest.kt
@@ -1,22 +1,21 @@
-package com.episode6.hackit.mockspresso.mockito
+package com.episode6.hackit.mockspresso.easymock.integration
 
 import com.episode6.hackit.mockspresso.BuildMockspresso
-import com.episode6.hackit.mockspresso.annotation.Dependency
 import com.episode6.hackit.mockspresso.annotation.RealObject
 import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
-import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.easymock.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.easymock.mockByEasyMock
 import com.episode6.hackit.mockspresso.testing.matches
-import com.nhaarman.mockitokotlin2.mock
+import org.easymock.Mock
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mock
 import javax.inject.Named
 
 /**
  * Test mocking using kotlin ext methods
  */
-class MockitoKotlinMockingTest {
+class EasyMockKotlinMockingTest {
 
   private interface TestDep1
   private interface TestDep2
@@ -28,11 +27,11 @@ class MockitoKotlinMockingTest {
 
   @get:Rule val mockspresso = BuildMockspresso.with()
       .injectBySimpleConfig()
-      .mockByMockito()
+      .mockByEasyMock()
       .buildRule()
 
   @Mock private lateinit var dep1: TestDep1
-  @Dependency @field:Named("dep2") private val dep2: TestDep2 = mock()
+  @Mock @field:Named("dep2") private lateinit var dep2: TestDep2
 
   @RealObject private lateinit var testObj: TestObj
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinMockingTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/MockitoKotlinMockingTest.kt
@@ -1,0 +1,45 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.annotation.Dependency
+import com.episode6.hackit.mockspresso.annotation.RealObject
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
+import com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
+import com.episode6.hackit.mockspresso.testing.matches
+import com.nhaarman.mockitokotlin2.mock
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import javax.inject.Named
+
+/**
+ * Test mocking using kotlin ext methods
+ */
+class MockitoKotlinMockingTest {
+
+  private interface TestDep1
+  private interface TestDep2
+  private interface TestDep3
+  private class TestObj(
+      val dep1: TestDep1,
+      @Named("dep2") val dep2: TestDep2,
+      val dep3: TestDep3)
+
+  @get:Rule val mockspresso = BuildMockspresso.with()
+      .injectBySimpleConfig()
+      .mockByMockito()
+      .buildRule()
+
+  @Mock private lateinit var dep1: TestDep1
+  @Dependency @field:Named("dep2") private val dep2: TestDep2 = mock()
+
+  @RealObject private lateinit var testObj: TestObj
+
+  @Test fun assertDepsAreMocks() {
+    assertThat(testObj.dep1).isEqualTo(dep1).matches(mockCondition())
+    assertThat(testObj.dep2).isEqualTo(dep2).matches(mockCondition())
+    assertThat(testObj.dep3).matches(mockCondition())
+  }
+}


### PR DESCRIPTION
Add and tests an extension method for easy mock. In this case we duplicated the kotlin integration tests from mockito. Also piggybacks a refactor for one of the mockito integration tests that was in the wrong directory