### PR TITLE
[Kotlin] Add extension methods for powermock plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,14 @@
      - **:mockspresso-mockito** module
      - `Builder.mockByMockito()`: Applies the mockito mocker config
      - `Builder.automaticFactories(vararg KClass<*>)`: Special object handling using MockitoAutoFactoryMaker
+     - **:mockspresso-mockito-powermock** module
+     - `Builder.mockByPowerMockito()`: Applies the power mockito mocker config
+     - `Builder.mockByPowerMockitoRule()`: Applies the power mockito + junit rule mocker config
      - **:mockspresso-easymock** module
      - `Builder.mockByEasyMock()`: Applies the easy mock mocker config
+     - **:mockspresso-easymock-powermock** module
+     - `Builder.mockByPowerMock()`: Applies the power mock mocker config
+     - `Builder.mockByPowerMockRule()`: Applies the power mock + junit rule mocker config     
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
@@ -1,0 +1,29 @@
+package com.episode6.hackit.mockspresso.easymock.powermock
+
+import com.episode6.hackit.mockspresso.Mockspresso
+
+/**
+ * Kotlin extension methods for mockspresso's Powermock + EasyMock plugins
+ */
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] for Powermock + EasyMock.
+ * Requires your project have a dependency on org.easymock:easymock v3.4,
+ * org.powermock:powermock-api-mockito2, and org.powermock:powermock-module-junit4 v1.7.0+.
+ * Also requires your test be runWith the [org.powermock.modules.junit4.PowerMockRunner]
+ * <p>
+ * WARNING, the @org.easymock.Mock annotation may not work correctly when using Mockspresso +
+ * easymock + PowerMockRunner, as easymock overwrites Mockspresso's annotated mocks at the last minute.
+ * To work around this problem, use powermock's @Mock, @MockNice and @MockStrict annotations instead.
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.mockByPowerMock(): Mockspresso.Builder = plugin(EasyPowerMockPlugin())
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] for Powermock + EasyMock AND
+ * applies a PowerMockRule as an outerRule to Mockspresso, so theres no need to use the PowerMockRunner
+ * Requires your project have the same dependencies as [mockByPowerMock]
+ * PLUS org.powermock:powermock-module-junit4-rule and org.powermock:powermock-classloading-xstream
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.mockByPowerMockRule(): Mockspresso.Builder = plugin(EasyPowerMockRulePlugin())

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExtTest.kt
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExtTest.kt
@@ -1,0 +1,46 @@
+package com.episode6.hackit.mockspresso.easymock.powermock
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import org.easymock.EasyMock.*
+import org.easymock.EasyMockSupport
+import org.easymock.Mock
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests [com.episode6.hackit.mockspresso.easymock.EasyMockPluginsExtKt]
+ */
+class EasyPowerMockPluginsExtTest {
+
+  @Mock
+  lateinit var builder: Mockspresso.Builder
+
+  @Before fun setup() {
+    EasyMockSupport.injectMocks(this)
+  }
+
+  @Test fun testPowerEasyMockExtensionSourceOfTruth() {
+    expect(builder.plugin(anyObject(EasyPowerMockPlugin::class.java))).andReturn(builder)
+    replay(builder)
+
+    val result = builder.mockByPowerMock()
+
+    verify(builder)
+    assertThat(result)
+        .isNotNull
+        .isEqualTo(builder)
+  }
+
+  @Test fun testPowerEasyMockRuleExtensionSourceOfTruth() {
+    expect(builder.plugin(anyObject(EasyPowerMockRulePlugin::class.java))).andReturn(builder)
+    replay(builder)
+
+    val result = builder.mockByPowerMockRule()
+
+    verify(builder)
+    assertThat(result)
+        .isNotNull
+        .isEqualTo(builder)
+  }
+}

--- a/mockspresso-mockito-powermock/build.gradle
+++ b/mockspresso-mockito-powermock/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
   testImplementation 'junit:junit'
   testImplementation 'org.easytesting:fest-assert-core'
+  testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
 }
 
 test {

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
@@ -1,0 +1,25 @@
+package com.episode6.hackit.mockspresso.mockito.powermock
+
+import com.episode6.hackit.mockspresso.Mockspresso
+
+/**
+ * Kotlin extension methods for mockspresso's Powermock + Mockito plugins
+ */
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] for Powermock + Mockito.
+ * Requires your project have a dependency on org.mockito:mockito-core v2.x,
+ * org.powermock:powermock-api-mockito2, and org.powermock:powermock-module-junit4 v1.7.0+.
+ * Also requires your test be runWith the [org.powermock.modules.junit4.PowerMockRunner]
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.mockByPowerMockito(): Mockspresso.Builder = plugin(PowerMockitoPlugin())
+
+/**
+ * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] for Powermock + Mockito
+ * AND applies a PowerMockRule as an outerRule to Mockspresso, so theres no need to use the PowerMockRunner
+ * Requires your project have the same dependencies as [mockByPowerMockito]
+ * PLUS org.powermock:powermock-module-junit4-rule and org.powermock:powermock-classloading-xstream
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.mockByPowerMockitoRule(): Mockspresso.Builder = plugin(PowerMockitoRulePlugin())

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExtTest.kt
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExtTest.kt
@@ -1,0 +1,30 @@
+package com.episode6.hackit.mockspresso.mockito.powermock
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+import org.mockito.stubbing.Answer
+
+/**
+ * Tests [com.episode6.hackit.mockspresso.mockito.powermock.PowerMockitoPluginsExtKt]
+ */
+class PowerMockitoPluginsExtTest {
+
+  val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
+
+  @Test
+  fun testPowerMockitoPluginSourceOfTruth() {
+    builder.mockByPowerMockito()
+
+    verify(builder).plugin(any<PowerMockitoPlugin>())
+  }
+
+  @Test
+  fun testPowerMockitoRulePluginSourceOfTruth() {
+    builder.mockByPowerMockitoRule()
+
+    verify(builder).plugin(any<PowerMockitoRulePlugin>())
+  }
+}


### PR DESCRIPTION
Adds extension methods for our power mock plugins to `Mockspresso.Builder

`mockByPowerMock()`
`mockByPowerMockRule()`
`mockByPowerMockito()`
`mockByPowerMockitoRule()`