### PR TITLE
[Kotlin] Add extension methods for guava plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
      - **:mockspresso-easymock-powermock** module
      - `Builder.mockByPowerMock()`: Applies the power mock mocker config
      - `Builder.mockByPowerMockRule()`: Applies the power mock + junit rule mocker config     
+     - **:mockspresso-guava** module
+     - `Builder.automaticListenableFutures()`: Adds special object handling for ListenableFutures
+     - `Builder.automaticSuppliers()`: Adds special object handling for Suppliers     
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-guava/build.gradle
+++ b/mockspresso-guava/build.gradle
@@ -12,5 +12,6 @@ dependencies {
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'junit:junit'
   testImplementation 'org.easytesting:fest-assert-core'
+  testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
 }
 

--- a/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExt.kt
+++ b/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExt.kt
@@ -1,0 +1,21 @@
+package com.episode6.hackit.mockspresso.guava
+
+import com.episode6.hackit.mockspresso.Mockspresso
+
+/**
+ * Kotlin extension methods for mockspresso's Guava plugins
+ */
+
+/**
+ * Applies a [com.episode6.hackit.mockspresso.api.SpecialObjectMaker] to provide real implementations
+ * of guava's [com.google.common.util.concurrent.ListenableFuture]s that return dependencies from mockspresso
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.automaticListenableFutures(): Mockspresso.Builder = specialObjectMaker(ListenableFutureMaker())
+
+/**
+ * Applies a [com.episode6.hackit.mockspresso.api.SpecialObjectMaker] to provide real implementations
+ * of guava's [com.google.common.base.Supplier]s that return dependencies from mockspresso
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.automaticSuppliers(): Mockspresso.Builder = specialObjectMaker(SupplierMaker())

--- a/mockspresso-guava/src/test/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExtTest.kt
+++ b/mockspresso-guava/src/test/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExtTest.kt
@@ -1,0 +1,30 @@
+package com.episode6.hackit.mockspresso.guava
+
+import com.episode6.hackit.mockspresso.Mockspresso
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+import org.mockito.stubbing.Answer
+
+/**
+ * Tests [com.episode6.hackit.mockspresso.dagger.DaggerPluginsExtKt]
+ */
+class GuavaPluginsExtTest {
+
+  val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
+
+  @Test
+  fun testListenableFutureSourceOfTruth() {
+    builder.automaticListenableFutures()
+
+    verify(builder).specialObjectMaker(any<ListenableFutureMaker>())
+  }
+
+  @Test
+  fun testSupplierSourceOfTruth() {
+    builder.automaticListenableFutures()
+
+    verify(builder).specialObjectMaker(any<SupplierMaker>())
+  }
+}

--- a/mockspresso-guava/src/test/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExtTest.kt
+++ b/mockspresso-guava/src/test/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExtTest.kt
@@ -23,7 +23,7 @@ class GuavaPluginsExtTest {
 
   @Test
   fun testSupplierSourceOfTruth() {
-    builder.automaticListenableFutures()
+    builder.automaticSuppliers()
 
     verify(builder).specialObjectMaker(any<SupplierMaker>())
   }


### PR DESCRIPTION
Adds extension methods to apply our special object makers for guava.

Includes:
`Mockspresso.Builder.automaticListenableFutures()`
`Mockspresso.Builder.automaticSuppliers()`