### PR TITLE
[Kotlin] Expose special object handlers for Providers/Lazies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@
      - **:mockspresso-basic-plugins** module
      - `Builder.injectBySimpleConfig()`: Applies the simple injection configuration plugin
      - `Builder.injectByJavaxConfig()`: Applies the Javax injection configuration plugin
+     - `Builder.automaticProviders()`: Adds special object handling for javax Providers
      - **:mockspresso-dagger** module
      - `Builder.injectByDaggerConfig()`: Applies the dagger injection configuration plugin
+     - `Builder.automaticLazies()`: Adds special object handling for dagger Lazies
      - **:mockspresso-mockito** module
      - `Builder.mockByMockito()`: Applies the mockito mocker config
      - `Builder.automaticFactories(vararg KClass<*>)`: Special object handling using MockitoAutoFactoryMaker

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
@@ -2,6 +2,7 @@ package com.episode6.hackit.mockspresso.basic.plugin
 
 import com.episode6.hackit.mockspresso.Mockspresso
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.javax.ProviderMaker
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
 
 /**
@@ -22,3 +23,10 @@ fun Mockspresso.Builder.injectBySimpleConfig(): Mockspresso.Builder = plugin(Sim
  */
 @JvmSynthetic
 fun Mockspresso.Builder.injectByJavaxConfig(): Mockspresso.Builder = plugin(JavaxInjectMockspressoPlugin())
+
+/**
+ * Adds a [com.episode6.hackit.mockspresso.api.SpecialObjectMaker] to handle [javax.inject.Provider]s
+ * and automatically pull their dependencies from Mockspresso's dependency map.
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.automaticProviders(): Mockspresso.Builder = specialObjectMaker(ProviderMaker())

--- a/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
+++ b/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
@@ -2,6 +2,7 @@ package com.episode6.hackit.mockspresso.basic.plugin
 
 import com.episode6.hackit.mockspresso.Mockspresso
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.javax.ProviderMaker
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -30,5 +31,12 @@ class BasicPluginsExtTest {
 
     assertThat(result).isEqualTo(builder)
     verify(builder).plugin(any<JavaxInjectMockspressoPlugin>())
+  }
+
+  @Test fun testAutomaticProvidersSourceOfTruth() {
+    val result = builder.automaticProviders()
+
+    assertThat(result).isEqualTo(builder)
+    verify(builder).specialObjectMaker(any<ProviderMaker>())
   }
 }

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
@@ -12,3 +12,10 @@ import com.episode6.hackit.mockspresso.Mockspresso
  */
 @JvmSynthetic
 fun Mockspresso.Builder.injectByDaggerConfig(): Mockspresso.Builder = plugin(DaggerMockspressoPlugin())
+
+/**
+ * Adds a [com.episode6.hackit.mockspresso.api.SpecialObjectMaker] to handle [dagger.Lazy]s
+ * and automatically pull their dependencies from Mockspresso's dependency map.
+ */
+@JvmSynthetic
+fun Mockspresso.Builder.automaticLazies(): Mockspresso.Builder = specialObjectMaker(DaggerLazyMaker())

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -22,4 +22,11 @@ class DaggerPluginsExtTest {
     assertThat(result).isEqualTo(builder)
     verify(builder).plugin(any<DaggerMockspressoPlugin>())
   }
+
+  @Test fun testAutomaticLaziesSourceOfTruth() {
+    val result = builder.automaticLazies()
+
+    assertThat(result).isEqualTo(builder)
+    verify(builder).specialObjectMaker(any<DaggerLazyMaker>())
+  }
 }


### PR DESCRIPTION
Exposes kotlin extension methods to add special object handling for providers an lazies. This allows kotlin users to add this support explicitly without piggybacking a specific injection config