### PR TITLE
[Java] Add JavaSupport objects to mirror kotlin extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@
      - `Builder.mockByPowerMockRule()`: Applies the power mock + junit rule mocker config     
      - **:mockspresso-guava** module
      - `Builder.automaticListenableFutures()`: Adds special object handling for ListenableFutures
-     - `Builder.automaticSuppliers()`: Adds special object handling for Suppliers     
+     - `Builder.automaticSuppliers()`: Adds special object handling for Suppliers
+ - Added java support classes with static methods to match our kotlin extension methods (see https://github.com/episode6/mockspresso/pull/33)
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
      - **:mockspresso-guava** module
      - `Builder.automaticListenableFutures()`: Adds special object handling for ListenableFutures
      - `Builder.automaticSuppliers()`: Adds special object handling for Suppliers
- - Added java support classes with static methods to match our kotlin extension methods (see https://github.com/episode6/mockspresso/pull/33)
+ - Added java support classes with static methods to match our kotlin extension methods (see https://github.com/episode6/mockspresso/pull/32)
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.basic.plugin
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
 import com.episode6.hackit.mockspresso.basic.plugin.javax.ProviderMaker
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
@@ -30,3 +31,14 @@ fun Mockspresso.Builder.injectByJavaxConfig(): Mockspresso.Builder = plugin(Java
  */
 @JvmSynthetic
 fun Mockspresso.Builder.automaticProviders(): Mockspresso.Builder = specialObjectMaker(ProviderMaker())
+
+/**
+ * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests
+ */
+@Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+@SinceKotlin("9999.0")
+object MockspressoBasicPluginsJavaSupport {
+  @JvmStatic fun injectBySimpleConfig(): MockspressoPlugin = MockspressoPlugin { it.injectBySimpleConfig() }
+  @JvmStatic fun injectByJavaxConfig(): MockspressoPlugin = MockspressoPlugin { it.injectByJavaxConfig() }
+  @JvmStatic fun automaticProviders(): MockspressoPlugin = MockspressoPlugin { it.automaticProviders() }
+}

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 
 /**
  * Kotlin extension methods for mockspresso's Dagger plugins
@@ -19,3 +20,13 @@ fun Mockspresso.Builder.injectByDaggerConfig(): Mockspresso.Builder = plugin(Dag
  */
 @JvmSynthetic
 fun Mockspresso.Builder.automaticLazies(): Mockspresso.Builder = specialObjectMaker(DaggerLazyMaker())
+
+/**
+ * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests
+ */
+@Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+@SinceKotlin("9999.0")
+object MockspressoDaggerPluginsJavaSupport {
+  @JvmStatic fun injectByDaggerConfig(): MockspressoPlugin = MockspressoPlugin { it.injectByDaggerConfig() }
+  @JvmStatic fun automaticLazies(): MockspressoPlugin = MockspressoPlugin { it.automaticLazies() }
+}

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.easymock.powermock
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 
 /**
  * Kotlin extension methods for mockspresso's Powermock + EasyMock plugins
@@ -27,3 +28,13 @@ fun Mockspresso.Builder.mockByPowerMock(): Mockspresso.Builder = plugin(EasyPowe
  */
 @JvmSynthetic
 fun Mockspresso.Builder.mockByPowerMockRule(): Mockspresso.Builder = plugin(EasyPowerMockRulePlugin())
+
+/**
+ * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests
+ */
+@Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+@SinceKotlin("9999.0")
+object MockspressoEasyPowerMockPluginsJavaSupport {
+  @JvmStatic fun mockByPowerMock(): MockspressoPlugin = MockspressoPlugin { it.mockByPowerMock() }
+  @JvmStatic fun mockByPowerMockRule(): MockspressoPlugin = MockspressoPlugin { it.mockByPowerMockRule() }
+}

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.easymock
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 
 /**
  * Kotlin extension methods for mockspresso's EasyMock plugins
@@ -11,3 +12,12 @@ import com.episode6.hackit.mockspresso.Mockspresso
  */
 @JvmSynthetic
 fun Mockspresso.Builder.mockByEasyMock(): Mockspresso.Builder = plugin(EasyMockPlugin())
+
+/**
+ * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests
+ */
+@Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+@SinceKotlin("9999.0")
+object MockspressoEasyMockPluginsJavaSupport {
+  @JvmStatic fun mockByEasyMock(): MockspressoPlugin = MockspressoPlugin { it.mockByEasyMock() }
+}

--- a/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExt.kt
+++ b/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.guava
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 
 /**
  * Kotlin extension methods for mockspresso's Guava plugins
@@ -19,3 +20,13 @@ fun Mockspresso.Builder.automaticListenableFutures(): Mockspresso.Builder = spec
  */
 @JvmSynthetic
 fun Mockspresso.Builder.automaticSuppliers(): Mockspresso.Builder = specialObjectMaker(SupplierMaker())
+
+/**
+ * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests
+ */
+@Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+@SinceKotlin("9999.0")
+object MockspressoGuavaPluginsJavaSupport {
+  @JvmStatic fun automaticListenableFutures(): MockspressoPlugin = MockspressoPlugin { it.automaticListenableFutures() }
+  @JvmStatic fun automaticSuppliers(): MockspressoPlugin = MockspressoPlugin { it.automaticSuppliers() }
+}

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.mockito.powermock
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 
 /**
  * Kotlin extension methods for mockspresso's Powermock + Mockito plugins
@@ -23,3 +24,13 @@ fun Mockspresso.Builder.mockByPowerMockito(): Mockspresso.Builder = plugin(Power
  */
 @JvmSynthetic
 fun Mockspresso.Builder.mockByPowerMockitoRule(): Mockspresso.Builder = plugin(PowerMockitoRulePlugin())
+
+/**
+ * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests
+ */
+@Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+@SinceKotlin("9999.0")
+object MockspressoPowerMockitoPluginsJavaSupport {
+  @JvmStatic fun mockByPowerMockito(): MockspressoPlugin = MockspressoPlugin { it.mockByPowerMockito() }
+  @JvmStatic fun mockByPowerMockitoRule(): MockspressoPlugin = MockspressoPlugin { it.mockByPowerMockitoRule() }
+}

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.mockito
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 import kotlin.reflect.KClass
 
 /**
@@ -30,3 +31,13 @@ fun Mockspresso.Builder.automaticFactories(vararg classes: Class<*>): Mockspress
 @JvmSynthetic
 fun Mockspresso.Builder.automaticFactories(vararg classes: KClass<*>): Mockspresso.Builder =
     automaticFactories(*classes.map { it.java }.toTypedArray())
+
+/**
+ * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests
+ */
+@Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
+@SinceKotlin("9999.0")
+object MockspressoMockitoPluginsJavaSupport {
+  @JvmStatic fun mockByMockito(): MockspressoPlugin = MockspressoPlugin { it.mockByMockito() }
+  @JvmStatic fun automaticFactories(vararg classes: Class<*>): MockspressoPlugin = MockspressoPlugin { it.automaticFactories(*classes) }
+}


### PR DESCRIPTION
Currently, kotlin and java support differ somewhat wildly. In an effort to codify a single api, this PR adds `JavaSupport` objects to the files that house our kotlin extension methods for plugins. These java support objects are only visibly to java, and contain static methods that mirror the kolin extension methods (except they return plugins).

This will allow us to define a single "api" for our extensions, that is used only slightly differently in java vs kotlin...

```kotlin
// kotlin
BuildMockspresso.with()
    .injectByDaggerConfig()
    .mockByMockito()
    .build()
```
translates to
```java
// java
BuildMockspresso.with()
    .plugin(injectByDaggerConfig())
    .plugin(mockByMockito())
    .build();
````

This is a pre-cursor to a mass deprecation of `:mockspresso-quick`, `:mockspresso-extend` and any public plugin implementations that should be internal.