### PR TITLE
[DEPRECATE] QuickMockspresso in favor of plugin methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
      - `Builder.automaticListenableFutures()`: Adds special object handling for ListenableFutures
      - `Builder.automaticSuppliers()`: Adds special object handling for Suppliers
  - Added java support classes with static methods to match our kotlin extension methods (see https://github.com/episode6/mockspresso/pull/32)
+ - **DEPRECATED** `QuickMockspresso` and entire `:mockspresso-quick` module 
 
 ### v0.0.16 - March 24th, 2019
  - Added new method to Mockspresso api `<T> void Mockspresso.inject(T, TypeToken<T>)`. This acts as a workaround when injecting a pre-existing object that is generic and has injected TypeVariables defined.

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CircularDependencyTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CircularDependencyTestEasyPowerMockRule.java
@@ -1,14 +1,17 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.exception.CircularDependencyError;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.CircularDependencies;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 
 /**
  * Tests {@link CircularDependencies}
@@ -16,9 +19,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CircularDependencyTestEasyPowerMockRule {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockRule())
       .buildRule();
 
   @Test(expected = CircularDependencyError.class)

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakerIntegrationTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakerIntegrationTestEasyPowerMockRule.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
@@ -12,6 +12,9 @@ import org.junit.runners.JUnit4;
 
 import javax.inject.Named;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -25,15 +28,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class CoffeeMakerIntegrationTestEasyPowerMockRule {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMockWithPowerMockRule()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockRule())
       .realObject(DependencyKey.of(Heater.class), CoffeeMakerComponents.RealHeater.class)
       .realObject(DependencyKey.of(Pump.class), CoffeeMakerComponents.RealWaterPump.class)
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @RealObject @Named("heater_name") final String heaterName = "NamedHeaterExample";

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakersMockEverythingTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakersMockEverythingTestEasyPowerMockRule.java
@@ -1,10 +1,10 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.easymock.Mock;
@@ -14,7 +14,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.easymock.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.easymock.EasyMock.*;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -32,13 +35,13 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class CoffeeMakersMockEverythingTestEasyPowerMockRule {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMockWithPowerMockRule()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockRule())
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Mock Water mWater;

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakersPumpTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakersPumpTestEasyPowerMockRule.java
@@ -1,7 +1,7 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -27,9 +29,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class CoffeeMakersPumpTestEasyPowerMockRule {
 
   private final PumpTestResources t = new PumpTestResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockRule())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/InvalidRuleTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/InvalidRuleTestEasyPowerMockRule.java
@@ -1,12 +1,14 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 import static org.easymock.EasyMock.createMock;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -17,9 +19,9 @@ public class InvalidRuleTestEasyPowerMockRule {
 
   private final TestClass mInitializerWithFields = new TestClass();
 
-  public final Mockspresso.Rule invalidMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMockWithPowerMockRule()
+  public final Mockspresso.Rule invalidMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockRule())
       .testResources(mInitializerWithFields)
       .buildRule();
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/PartialSharedResorcesTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/PartialSharedResorcesTestEasyPowerMockRule.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 import static org.easymock.EasyMock.*;
 
 
@@ -23,9 +25,9 @@ import static org.easymock.EasyMock.*;
 public class PartialSharedResorcesTestEasyPowerMockRule {
 
   private final PartialSharedResources t = new PartialSharedResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockRule())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/PumpTestResources.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/PumpTestResources.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -10,6 +9,7 @@ import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
 import org.easymock.Mock;
 import org.junit.Before;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.easymock.powermock.Conditions.mockCondition;
 import static org.easymock.EasyMock.*;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -35,8 +35,8 @@ public class PumpTestResources {
     expect(mPump.pump()).andReturn(mWater);
     replay(mPump);
 
-    mSimpleCoffeeMaker = BuildQuickMockspresso.upon(mockspresso)
-        .injector().simple()
+    mSimpleCoffeeMaker = mockspresso.buildUpon()
+        .plugin(injectBySimpleConfig())
         .build().create(CoffeeMakers.SimpleCoffeeMaker.class);
   }
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/UnmappedTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/UnmappedTestEasyPowerMockRule.java
@@ -1,11 +1,11 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.annotation.Unmapped;
 import com.episode6.hackit.mockspresso.api.ObjectProvider;
 import com.episode6.hackit.mockspresso.exception.RepeatedDependencyDefinedException;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
@@ -16,7 +16,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import javax.inject.Provider;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
 import static com.episode6.hackit.mockspresso.easymock.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -28,9 +30,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @PrepareForTest(UnmappedTestEasyPowerMockRule.TestClass.class)
 public class UnmappedTestEasyPowerMockRule {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockRule())
       .buildRule();
 
   @Mock Provider<CoffeeGrounds> mGroundsProvider;

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CircularDependencyTestEasyPowerMockRunner.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CircularDependencyTestEasyPowerMockRunner.java
@@ -1,14 +1,17 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.exception.CircularDependencyError;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.CircularDependencies;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMock;
 
 /**
  * Tests {@link CircularDependencies}
@@ -16,9 +19,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 public class CircularDependencyTestEasyPowerMockRunner {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMock())
       .buildRule();
 
   @Test(expected = CircularDependencyError.class)

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakerIntegrationTestEasyPowerMockRunner.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakerIntegrationTestEasyPowerMockRunner.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
@@ -12,6 +12,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.inject.Named;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMock;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -25,15 +28,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(PowerMockRunner.class)
 public class CoffeeMakerIntegrationTestEasyPowerMockRunner {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMockWithPowerMock()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMock())
       .realObject(DependencyKey.of(Heater.class), CoffeeMakerComponents.RealHeater.class)
       .realObject(DependencyKey.of(Pump.class), CoffeeMakerComponents.RealWaterPump.class)
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @RealObject @Named("heater_name") final String heaterName = "NamedHeaterExample";

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakersMockEverythingTestEasyPowerMockRunner.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakersMockEverythingTestEasyPowerMockRunner.java
@@ -1,10 +1,10 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.junit.Before;
@@ -14,7 +14,10 @@ import org.junit.runner.RunWith;
 import org.powermock.api.easymock.annotation.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.easymock.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMock;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.easymock.EasyMock.*;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -32,13 +35,13 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(PowerMockRunner.class)
 public class CoffeeMakersMockEverythingTestEasyPowerMockRunner {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMockWithPowerMock()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMock())
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Mock Water mWater;

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakersPumpTestEasyPowerMockRunner.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakersPumpTestEasyPowerMockRunner.java
@@ -1,7 +1,7 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMock;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -27,9 +29,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class CoffeeMakersPumpTestEasyPowerMockRunner {
 
   private final PumpTestResources t = new PumpTestResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMock())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/InvalidRuleTestEasyPowerMockRunner.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/InvalidRuleTestEasyPowerMockRunner.java
@@ -1,12 +1,14 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMock;
 import static org.easymock.EasyMock.createMock;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -17,9 +19,9 @@ public class InvalidRuleTestEasyPowerMockRunner {
 
   private final TestClass mInitializerWithFields = new TestClass();
 
-  public final Mockspresso.Rule invalidMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMockWithPowerMock()
+  public final Mockspresso.Rule invalidMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMock())
       .testResources(mInitializerWithFields)
       .buildRule();
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/PartialSharedResorcesTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/PartialSharedResorcesTestEasyPowerMockRule.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMockRule;
 import static org.easymock.EasyMock.*;
 
 
@@ -23,9 +25,9 @@ import static org.easymock.EasyMock.*;
 public class PartialSharedResorcesTestEasyPowerMockRule {
 
   private final PartialSharedResources t = new PartialSharedResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockRule())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/PumpTestResources.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/PumpTestResources.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -10,6 +9,7 @@ import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
 import org.easymock.Mock;
 import org.junit.Before;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.easymock.powermock.Conditions.mockCondition;
 import static org.easymock.EasyMock.*;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -35,8 +35,8 @@ public class PumpTestResources {
     expect(mPump.pump()).andReturn(mWater);
     replay(mPump);
 
-    mSimpleCoffeeMaker = BuildQuickMockspresso.upon(mockspresso)
-        .injector().simple()
+    mSimpleCoffeeMaker = mockspresso.buildUpon()
+        .plugin(injectBySimpleConfig())
         .build().create(CoffeeMakers.SimpleCoffeeMaker.class);
   }
 

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/UnmappedTestEasyPowerMockRunner.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/UnmappedTestEasyPowerMockRunner.java
@@ -1,11 +1,11 @@
 package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.annotation.Unmapped;
 import com.episode6.hackit.mockspresso.api.ObjectProvider;
 import com.episode6.hackit.mockspresso.exception.RepeatedDependencyDefinedException;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
@@ -18,7 +18,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.inject.Provider;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
 import static com.episode6.hackit.mockspresso.easymock.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.easymock.powermock.MockspressoEasyPowerMockPluginsJavaSupport.mockByPowerMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -31,9 +33,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @PrepareForTest(UnmappedTestEasyPowerMockRunner.TestClass.class)
 public class UnmappedTestEasyPowerMockRunner {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMockWithPowerMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMock())
       .buildRule();
 
   @Mock Provider<CoffeeGrounds> mGroundsProvider;

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CircularDependencyTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CircularDependencyTestEasyMock.java
@@ -1,14 +1,17 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.exception.CircularDependencyError;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.CircularDependencies;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 
 /**
  * Tests {@link CircularDependencies}
@@ -16,9 +19,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CircularDependencyTestEasyMock {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByEasyMock())
       .buildRule();
 
   @Test(expected = CircularDependencyError.class)

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakerIntegrationTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakerIntegrationTestEasyMock.java
@@ -1,9 +1,9 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.Dependency;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
@@ -13,6 +13,9 @@ import org.junit.runners.JUnit4;
 
 import javax.inject.Named;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -26,15 +29,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class CoffeeMakerIntegrationTestEasyMock {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMock()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByEasyMock())
       .realObject(DependencyKey.of(Heater.class), CoffeeMakerComponents.RealHeater.class)
       .realObject(DependencyKey.of(Pump.class), CoffeeMakerComponents.RealWaterPump.class)
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Dependency @Named("heater_name") final String heaterName = "NamedHeaterExample";

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakersMockEverythingTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakersMockEverythingTestEasyMock.java
@@ -1,10 +1,10 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
@@ -15,7 +15,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.easymock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.easymock.EasyMock.*;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -33,13 +36,13 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class CoffeeMakersMockEverythingTestEasyMock {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMock()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByEasyMock())
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Mock Water mWater;

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakersPumpTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakersPumpTestEasyMock.java
@@ -1,7 +1,7 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -27,9 +29,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class CoffeeMakersPumpTestEasyMock {
 
   private final PumpTestResources t = new PumpTestResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByEasyMock())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/DependencyImportTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/DependencyImportTestEasyMock.java
@@ -1,23 +1,25 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.Dependency;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.TestQualifierAnnotation;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 /**
  * Tests importing fields annotated with {@link Dependency}
  */
 public class DependencyImportTestEasyMock {
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMock()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByEasyMock())
       .buildRule();
 
   @Dependency(bindAs = Pump.class) CoffeeMakerComponents.RealWaterPump mRealPump = new CoffeeMakerComponents.RealWaterPump();

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/InvalidRuleTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/InvalidRuleTestEasyMock.java
@@ -1,12 +1,14 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.easymock.Mock;
 import org.junit.Before;
 import org.junit.Test;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 import static org.easymock.EasyMock.createMock;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -17,9 +19,9 @@ public class InvalidRuleTestEasyMock {
 
   private final TestClass mInitializerWithFields = new TestClass();
 
-  public final Mockspresso.Rule invalidMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().easyMock()
+  public final Mockspresso.Rule invalidMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByEasyMock())
       .testResources(mInitializerWithFields)
       .buildRule();
 

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/PartialSharedResorcesTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/PartialSharedResorcesTestEasyMock.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
@@ -13,6 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 import static org.easymock.EasyMock.*;
 
 
@@ -23,9 +25,9 @@ import static org.easymock.EasyMock.*;
 public class PartialSharedResorcesTestEasyMock {
 
   private final PartialSharedResources t = new PartialSharedResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByEasyMock())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/PumpTestResources.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/PumpTestResources.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.easymock.integration;
 
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -10,6 +9,7 @@ import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
 import org.easymock.Mock;
 import org.junit.Before;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.easymock.Conditions.mockCondition;
 import static org.easymock.EasyMock.*;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -35,8 +35,8 @@ public class PumpTestResources {
     expect(mPump.pump()).andReturn(mWater);
     replay(mPump);
 
-    mSimpleCoffeeMaker = BuildQuickMockspresso.upon(mockspresso)
-        .injector().simple()
+    mSimpleCoffeeMaker = mockspresso.buildUpon()
+        .plugin(injectBySimpleConfig())
         .build().create(CoffeeMakers.SimpleCoffeeMaker.class);
   }
 

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/UnmappedTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/UnmappedTestEasyMock.java
@@ -1,11 +1,11 @@
 package com.episode6.hackit.mockspresso.easymock.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.annotation.Unmapped;
 import com.episode6.hackit.mockspresso.api.ObjectProvider;
 import com.episode6.hackit.mockspresso.exception.RepeatedDependencyDefinedException;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
@@ -15,7 +15,9 @@ import org.junit.Test;
 
 import javax.inject.Provider;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
 import static com.episode6.hackit.mockspresso.easymock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.easymock.MockspressoEasyMockPluginsJavaSupport.mockByEasyMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -26,9 +28,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
  */
 public class UnmappedTestEasyMock {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().easyMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByEasyMock())
       .buildRule();
 
   @Mock Provider<CoffeeGrounds> mGroundsProvider;

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CircularDependencyTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CircularDependencyTestPowerMockitoRule.java
@@ -1,14 +1,17 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.exception.CircularDependencyError;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.CircularDependencies;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockitoRule;
 
 /**
  * Tests {@link CircularDependencies}
@@ -16,9 +19,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CircularDependencyTestPowerMockitoRule {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockitoRule())
       .buildRule();
 
   @Test(expected = CircularDependencyError.class)

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakerIntegrationTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakerIntegrationTestPowerMockitoRule.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
@@ -12,6 +12,9 @@ import org.junit.runners.JUnit4;
 
 import javax.inject.Named;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockitoRule;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -25,15 +28,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class CoffeeMakerIntegrationTestPowerMockitoRule {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockitoWithPowerMockRule()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockitoRule())
       .realObject(DependencyKey.of(Heater.class), CoffeeMakerComponents.RealHeater.class)
       .realObject(DependencyKey.of(Pump.class), CoffeeMakerComponents.RealWaterPump.class)
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @RealObject @Named("heater_name") final String heaterName = "NamedHeaterExample";

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakersMockEverythingTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakersMockEverythingTestPowerMockitoRule.java
@@ -1,10 +1,10 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.junit.Before;
@@ -14,7 +14,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockitoRule;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -33,13 +36,13 @@ import static org.mockito.Mockito.when;
 @RunWith(JUnit4.class)
 public class CoffeeMakersMockEverythingTestPowerMockitoRule {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockitoWithPowerMockRule()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockitoRule())
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Mock Water mWater;

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakersPumpTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakersPumpTestPowerMockitoRule.java
@@ -1,7 +1,7 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockitoRule;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -27,9 +29,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class CoffeeMakersPumpTestPowerMockitoRule {
 
   private final PumpTestResources t = new PumpTestResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockitoRule())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/InvalidRuleTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/InvalidRuleTestPowerMockitoRule.java
@@ -1,12 +1,14 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockitoRule;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -18,9 +20,9 @@ public class InvalidRuleTestPowerMockitoRule {
 
   private final TestClass mInitializerWithFields = new TestClass();
 
-  public final Mockspresso.Rule invalidMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockitoWithPowerMockRule()
+  public final Mockspresso.Rule invalidMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockitoRule())
       .testResources(mInitializerWithFields)
       .buildRule();
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/PartialSharedResorcesTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/PartialSharedResorcesTestPowerMockitoRule.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
@@ -13,6 +13,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockitoRule;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,9 +25,9 @@ import static org.mockito.Mockito.when;
 public class PartialSharedResorcesTestPowerMockitoRule {
 
   private final PartialSharedResources t = new PartialSharedResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockitoRule())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/PumpTestResources.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/PumpTestResources.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -10,6 +9,7 @@ import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
 import org.junit.Before;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.powermock.Conditions.mockCondition;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -35,8 +35,8 @@ public class PumpTestResources {
   public void setup(Mockspresso mockspresso) {
     when(mPump.pump()).thenReturn(mWater);
 
-    mSimpleCoffeeMaker = BuildQuickMockspresso.upon(mockspresso)
-        .injector().simple()
+    mSimpleCoffeeMaker = mockspresso.buildUpon()
+        .plugin(injectBySimpleConfig())
         .build().create(CoffeeMakers.SimpleCoffeeMaker.class);
   }
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/UnmappedTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/UnmappedTestPowerMockitoRule.java
@@ -1,11 +1,11 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.annotation.Unmapped;
 import com.episode6.hackit.mockspresso.api.ObjectProvider;
 import com.episode6.hackit.mockspresso.exception.RepeatedDependencyDefinedException;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
@@ -16,7 +16,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import javax.inject.Provider;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
 import static com.episode6.hackit.mockspresso.mockito.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockitoRule;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -27,9 +29,9 @@ import static org.mockito.Mockito.when;
 @PrepareForTest(UnmappedTestPowerMockitoRule.TestClass.class)
 public class UnmappedTestPowerMockitoRule {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMockRule()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockitoRule())
       .buildRule();
 
   @Mock Provider<CoffeeGrounds> mGroundsProvider;

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CircularDependencyTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CircularDependencyTestPowerMockitoRunner.java
@@ -1,14 +1,17 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.exception.CircularDependencyError;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.CircularDependencies;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockito;
 
 /**
  * Tests {@link CircularDependencies}
@@ -16,9 +19,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 public class CircularDependencyTestPowerMockitoRunner {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockito())
       .buildRule();
 
   @Test(expected = CircularDependencyError.class)

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakerIntegrationTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakerIntegrationTestPowerMockitoRunner.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
@@ -12,6 +12,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.inject.Named;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockito;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -25,15 +28,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(PowerMockRunner.class)
 public class CoffeeMakerIntegrationTestPowerMockitoRunner {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockitoWithPowerMock()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockito())
       .realObject(DependencyKey.of(Heater.class), CoffeeMakerComponents.RealHeater.class)
       .realObject(DependencyKey.of(Pump.class), CoffeeMakerComponents.RealWaterPump.class)
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @RealObject @Named("heater_name") final String heaterName = "NamedHeaterExample";

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakersMockEverythingTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakersMockEverythingTestPowerMockitoRunner.java
@@ -1,10 +1,10 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.junit.Before;
@@ -14,7 +14,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockito;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -33,13 +36,13 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 public class CoffeeMakersMockEverythingTestPowerMockitoRunner {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockitoWithPowerMock()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockito())
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Mock Water mWater;

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakersPumpTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakersPumpTestPowerMockitoRunner.java
@@ -1,7 +1,7 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockito;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -27,9 +29,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class CoffeeMakersPumpTestPowerMockitoRunner {
 
   private final PumpTestResources t = new PumpTestResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockito())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/InvalidRuleTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/InvalidRuleTestPowerMockitoRunner.java
@@ -1,12 +1,14 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockito;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -18,9 +20,9 @@ public class InvalidRuleTestPowerMockitoRunner {
 
   private final TestClass mInitializerWithFields = new TestClass();
 
-  public final Mockspresso.Rule invalidMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockitoWithPowerMock()
+  public final Mockspresso.Rule invalidMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByPowerMockito())
       .testResources(mInitializerWithFields)
       .buildRule();
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/PartialSharedResorcesTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/PartialSharedResorcesTestPowerMockitoRunner.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
@@ -13,6 +13,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockito;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,9 +25,9 @@ import static org.mockito.Mockito.when;
 public class PartialSharedResorcesTestPowerMockitoRunner {
 
   private final PartialSharedResources t = new PartialSharedResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockito())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/PumpTestResources.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/PumpTestResources.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -10,6 +9,7 @@ import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
 import org.junit.Before;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.powermock.Conditions.mockCondition;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -35,8 +35,8 @@ public class PumpTestResources {
   public void setup(Mockspresso mockspresso) {
     when(mPump.pump()).thenReturn(mWater);
 
-    mSimpleCoffeeMaker = BuildQuickMockspresso.upon(mockspresso)
-        .injector().simple()
+    mSimpleCoffeeMaker = mockspresso.buildUpon()
+        .plugin(injectBySimpleConfig())
         .build().create(CoffeeMakers.SimpleCoffeeMaker.class);
   }
 

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/UnmappedTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/UnmappedTestPowerMockitoRunner.java
@@ -1,11 +1,11 @@
 package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.annotation.Unmapped;
 import com.episode6.hackit.mockspresso.api.ObjectProvider;
 import com.episode6.hackit.mockspresso.exception.RepeatedDependencyDefinedException;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
@@ -18,7 +18,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.inject.Provider;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
 import static com.episode6.hackit.mockspresso.mockito.powermock.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.powermock.MockspressoPowerMockitoPluginsJavaSupport.mockByPowerMockito;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -30,9 +32,9 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 public class UnmappedTestPowerMockitoRunner {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockitoWithPowerMock()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByPowerMockito())
       .buildRule();
 
   @Mock Provider<CoffeeGrounds> mGroundsProvider;

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/AutoFactoryTest.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/AutoFactoryTest.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGroundsFactory;
@@ -13,7 +13,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.automaticFactories;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 /**
@@ -22,10 +25,10 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class AutoFactoryTest {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockito()
-      .plugin().automaticFactories(CoffeeGroundsFactory.class)
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByMockito())
+      .plugin(automaticFactories(CoffeeGroundsFactory.class))
       .buildRule();
 
   // this mock should be returned by the CoffeeGroundsFactory that gets injected into mCoffeeMaker

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CircularDependencyTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CircularDependencyTestMockito.java
@@ -1,14 +1,17 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.exception.CircularDependencyError;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.CircularDependencies;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 
 /**
  * Tests {@link CircularDependencies}
@@ -16,9 +19,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CircularDependencyTestMockito {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByMockito())
       .buildRule();
 
   @Test(expected = CircularDependencyError.class)

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakerIntegrationTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakerIntegrationTestMockito.java
@@ -1,9 +1,9 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.Dependency;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
@@ -13,6 +13,9 @@ import org.junit.runners.JUnit4;
 
 import javax.inject.Named;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -26,15 +29,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(JUnit4.class)
 public class CoffeeMakerIntegrationTestMockito {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByMockito())
       .realObject(DependencyKey.of(Heater.class), CoffeeMakerComponents.RealHeater.class)
       .realObject(DependencyKey.of(Pump.class), CoffeeMakerComponents.RealWaterPump.class)
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Dependency @Named("heater_name") final String heaterName = "NamedHeaterExample";

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakersMockEverythingTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakersMockEverythingTestMockito.java
@@ -1,10 +1,10 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
@@ -15,7 +15,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -34,13 +37,13 @@ import static org.mockito.Mockito.when;
 @RunWith(JUnit4.class)
 public class CoffeeMakersMockEverythingTestMockito {
 
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByMockito())
       .buildRule();
 
-  private final QuickMockspresso injectionMockspresso = simpleMockspresso.buildUpon()
-      .injector().javax()
+  private final Mockspresso injectionMockspresso = simpleMockspresso.buildUpon()
+      .plugin(injectByJavaxConfig())
       .build();
 
   @Mock Water mWater;

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakersPumpTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakersPumpTestMockito.java
@@ -1,7 +1,7 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static com.episode6.hackit.mockspresso.testing.Conditions.rawClass;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -27,9 +29,9 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class CoffeeMakersPumpTestMockito {
 
   private final PumpTestResources t = new PumpTestResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByMockito())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/DependencyImportTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/DependencyImportTestMockito.java
@@ -1,23 +1,25 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.Dependency;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.TestQualifierAnnotation;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import org.junit.Rule;
 import org.junit.Test;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 /**
  * Tests importing fields annotated with {@link Dependency}
  */
 public class DependencyImportTestMockito {
-  @Rule public final QuickMockspresso.Rule simpleMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule simpleMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByMockito())
       .buildRule();
 
   @Dependency(bindAs = Pump.class) CoffeeMakerComponents.RealWaterPump mRealPump = new CoffeeMakerComponents.RealWaterPump();

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/GenericConstructorTest.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/GenericConstructorTest.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
+import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
-import com.episode6.hackit.mockspresso.quick.QuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,7 +13,10 @@ import org.mockito.Mockito;
 
 import javax.inject.Inject;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 /**
@@ -56,9 +59,9 @@ public class GenericConstructorTest {
     @RealObject TestMethodInjectGeneric<TestObject> testGeneric;
   }
 
-  @Rule public final QuickMockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByMockito())
       .buildRule();
 
   @Test public void testCreateViaTypeToken() {
@@ -89,7 +92,7 @@ public class GenericConstructorTest {
 
   @Test public void testInjectViaAnnotation() {
     TestInjectResources resources = new TestInjectResources();
-    mockspresso.buildUpon().injector().javax().testResources(resources).build();
+    mockspresso.buildUpon().plugin(injectByJavaxConfig()).testResources(resources).build();
 
     assertThat(resources.testGeneric).isNotNull();
     assertThat(resources.testGeneric.obj).isNotNull().is(mockCondition());
@@ -97,7 +100,7 @@ public class GenericConstructorTest {
 
   @Test public void testMethodInjectViaAnnotation() {
     TestMethodInjectResources resources = new TestMethodInjectResources();
-    mockspresso.buildUpon().injector().javax().testResources(resources).build();
+    mockspresso.buildUpon().plugin(injectByJavaxConfig()).testResources(resources).build();
 
     assertThat(resources.testGeneric).isNotNull();
     assertThat(resources.testGeneric.obj).isNotNull().is(mockCondition());
@@ -108,7 +111,7 @@ public class GenericConstructorTest {
     TestObject testMock = Mockito.mock(TestObject.class);
 
     mockspresso.buildUpon()
-        .injector().javax()
+        .plugin(injectByJavaxConfig())
         .dependency(TestObject.class, testMock)
         .build()
         .inject(testGeneric, new TypeToken<TestInjectGeneric<TestObject>>() {});
@@ -124,7 +127,7 @@ public class GenericConstructorTest {
     TestObject testMock = Mockito.mock(TestObject.class);
 
     mockspresso.buildUpon()
-        .injector().javax()
+        .plugin(injectByJavaxConfig())
         .dependency(TestObject.class, testMock)
         .build()
         .inject(testGeneric, new TypeToken<TestMethodInjectGeneric<TestObject>>() {});

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/InvalidRuleTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/InvalidRuleTestMockito.java
@@ -1,12 +1,14 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -18,9 +20,9 @@ public class InvalidRuleTestMockito {
 
   private final TestClass mInitializerWithFields = new TestClass();
 
-  public final Mockspresso.Rule invalidMockspresso = BuildQuickMockspresso.with()
-      .injector().simple()
-      .mocker().mockito()
+  public final Mockspresso.Rule invalidMockspresso = BuildMockspresso.with()
+      .plugin(injectBySimpleConfig())
+      .plugin(mockByMockito())
       .testResources(mInitializerWithFields)
       .buildRule();
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/PartialSharedResorcesTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/PartialSharedResorcesTestMockito.java
@@ -1,8 +1,8 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
@@ -13,6 +13,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,9 +25,9 @@ import static org.mockito.Mockito.when;
 public class PartialSharedResorcesTestMockito {
 
   private final PartialSharedResources t = new PartialSharedResources();
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByMockito())
       .testResources(t)
       .buildRule();
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/PumpTestResources.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/PumpTestResources.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.mockito.integration;
 
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Pump;
@@ -10,6 +9,7 @@ import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Water;
 import org.junit.Before;
 import org.mockito.Mock;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectBySimpleConfig;
 import static com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -35,8 +35,8 @@ public class PumpTestResources {
   public void setup(Mockspresso mockspresso) {
     when(mPump.pump()).thenReturn(mWater);
 
-    mSimpleCoffeeMaker = BuildQuickMockspresso.upon(mockspresso)
-        .injector().simple()
+    mSimpleCoffeeMaker = mockspresso.buildUpon()
+        .plugin(injectBySimpleConfig())
         .build().create(CoffeeMakers.SimpleCoffeeMaker.class);
   }
 

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/UnmappedTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/UnmappedTestMockito.java
@@ -1,11 +1,11 @@
 package com.episode6.hackit.mockspresso.mockito.integration;
 
+import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
 import com.episode6.hackit.mockspresso.annotation.Unmapped;
 import com.episode6.hackit.mockspresso.api.ObjectProvider;
 import com.episode6.hackit.mockspresso.exception.RepeatedDependencyDefinedException;
-import com.episode6.hackit.mockspresso.quick.BuildQuickMockspresso;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.Coffee;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeGrounds;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers;
@@ -15,7 +15,9 @@ import org.mockito.Mock;
 
 import javax.inject.Provider;
 
+import static com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport.injectByJavaxConfig;
 import static com.episode6.hackit.mockspresso.mockito.Conditions.mockCondition;
+import static com.episode6.hackit.mockspresso.mockito.MockspressoMockitoPluginsJavaSupport.mockByMockito;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -25,9 +27,9 @@ import static org.mockito.Mockito.when;
  */
 public class UnmappedTestMockito {
 
-  @Rule public final Mockspresso.Rule mockspresso = BuildQuickMockspresso.with()
-      .injector().javax()
-      .mocker().mockito()
+  @Rule public final Mockspresso.Rule mockspresso = BuildMockspresso.with()
+      .plugin(injectByJavaxConfig())
+      .plugin(mockByMockito())
       .buildRule();
 
   @Mock Provider<CoffeeGrounds> mGroundsProvider;

--- a/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/BuildQuickMockspresso.java
+++ b/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/BuildQuickMockspresso.java
@@ -6,12 +6,16 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Entry-point to create new instances of {@link QuickMockspresso.Builder}
+ * @deprecated see {@link DEPRECATEDKt}
  */
+@Deprecated
 public class BuildQuickMockspresso {
 
   /**
    * @return a brand new instance of {@link QuickMockspresso.Builder}
+   * @deprecated see {@link DEPRECATEDKt}
    */
+  @Deprecated
   @NotNull public static QuickMockspresso.Builder with() {
     return new QuickMockspressoImpl.Builder(BuildMockspresso.with());
   }
@@ -20,7 +24,9 @@ public class BuildQuickMockspresso {
    * Builds upon an existing mockspresso instance with a new {@link QuickMockspresso.Builder}
    * @param mockspresso The {@link Mockspresso} instance to wrap
    * @return and new {@link QuickMockspresso.Builder} built upon the supplied mockspresso instance.
+   * @deprecated see {@link DEPRECATEDKt}
    */
+  @Deprecated
   @NotNull public static QuickMockspresso.Builder upon(@NotNull Mockspresso mockspresso) {
     return new QuickMockspressoImpl.Builder(mockspresso.buildUpon());
   }

--- a/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/DEPRECATED.kt
+++ b/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/DEPRECATED.kt
@@ -1,0 +1,11 @@
+package com.episode6.hackit.mockspresso.quick
+
+const val QUICK_DEPRECATION_MESSAGE = """
+  The :mockspresso-quick and :mockspresso-extend modules are now deprecated and
+  slated to be removed in a future major release.
+
+  Kotlin usage is now the primary focus of mockspresso, and all the functionality here
+  can now be found in kotlin extension methods in each plugin's module.
+
+  For more details see [TODO: ADD URL OF DEPRECATION EXPLINATION]
+"""

--- a/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/DEPRECATED.kt
+++ b/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/DEPRECATED.kt
@@ -1,11 +1,11 @@
 package com.episode6.hackit.mockspresso.quick
 
 const val QUICK_DEPRECATION_MESSAGE = """
-  The :mockspresso-quick and :mockspresso-extend modules are now deprecated and
-  slated to be removed in a future major release.
+  The :mockspresso-quick module is now deprecated and slated to be removed in a future release.
 
   Kotlin usage is now the primary focus of mockspresso, and all the functionality here
   can now be found in kotlin extension methods in each plugin's module.
 
-  For more details see [TODO: ADD URL OF DEPRECATION EXPLINATION]
+  Java users can still access all of this functionality via the *PluginsJavaSupport classes
+  also available in each module.
 """

--- a/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspresso.java
+++ b/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspresso.java
@@ -6,13 +6,26 @@ import com.episode6.hackit.mockspresso.api.MockspressoPlugin;
 import com.episode6.hackit.mockspresso.extend.MockspressoExtension;
 import org.jetbrains.annotations.NotNull;
 
+import static com.episode6.hackit.mockspresso.quick.DEPRECATEDKt.QUICK_DEPRECATION_MESSAGE;
+
 /**
  * A mockspresso extension for bootstrapping / general use
+ *
+ * @deprecated see {@link DEPRECATEDKt}
  */
+@Deprecated
 public interface QuickMockspresso extends MockspressoExtension<QuickMockspresso.Builder> {
 
+  /**
+   * @deprecated see {@link DEPRECATEDKt}
+   */
+  @Deprecated
   interface Rule extends MockspressoExtension.Rule<QuickMockspresso.Builder> { }
 
+  /**
+   * @deprecated see {@link DEPRECATEDKt}
+   */
+  @Deprecated
   interface Builder extends MockspressoExtension.Builder<
       QuickMockspresso,
       QuickMockspresso.Rule,
@@ -40,7 +53,9 @@ public interface QuickMockspresso extends MockspressoExtension<QuickMockspresso.
 
   /**
    * A selector for one of the built in injection configs
+   * @deprecated see {@link DEPRECATEDKt}
    */
+  @Deprecated
   interface InjectorPicker {
 
     /**
@@ -72,7 +87,9 @@ public interface QuickMockspresso extends MockspressoExtension<QuickMockspresso.
 
   /**
    * A selector for one of the built-in mocker configs
+   * @deprecated see {@link DEPRECATEDKt}
    */
+  @Deprecated
   interface MockerPicker {
 
     /**
@@ -139,7 +156,9 @@ public interface QuickMockspresso extends MockspressoExtension<QuickMockspresso.
 
   /**
    * A selector for one of the built in plugins
+   * @deprecated see {@link DEPRECATEDKt}
    */
+  @Deprecated
   interface PluginPicker {
 
     /**

--- a/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspressoImpl.kt
+++ b/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspressoImpl.kt
@@ -7,16 +7,19 @@ import com.episode6.hackit.mockspresso.quick.exception.MissingDependencyError
 /**
  * Internal implementation for quick mockspresso
  */
+@Deprecated(QUICK_DEPRECATION_MESSAGE)
 internal class QuickMockspressoImpl(delegate: Mockspresso) : QuickMockspresso,
     AbstractMockspressoExtension<QuickMockspresso.Builder>(
         delegate,
         ::Builder) {
 
+  @Deprecated(QUICK_DEPRECATION_MESSAGE)
   internal class Rule(delegate: Mockspresso.Rule) : QuickMockspresso.Rule,
       AbstractMockspressoExtension.Rule<QuickMockspresso.Builder>(
           delegate,
           ::Builder)
 
+  @Deprecated(QUICK_DEPRECATION_MESSAGE)
   internal class Builder(delegate: Mockspresso.Builder) : QuickMockspresso.Builder,
       AbstractMockspressoExtension.Builder<QuickMockspresso, QuickMockspresso.Rule, QuickMockspresso.Builder>(
           delegate,
@@ -30,6 +33,7 @@ internal class QuickMockspressoImpl(delegate: Mockspresso) : QuickMockspresso,
     override fun mocker(): QuickMockspresso.MockerPicker = pluginPicker
   }
 
+  @Deprecated(QUICK_DEPRECATION_MESSAGE)
   internal class PluginPickerImpl(private val builder: QuickMockspresso.Builder) :
       QuickMockspresso.InjectorPicker, QuickMockspresso.MockerPicker, QuickMockspresso.PluginPicker {
 

--- a/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspressoImpl.kt
+++ b/mockspresso-quick/src/main/java/com/episode6/hackit/mockspresso/quick/QuickMockspressoImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package com.episode6.hackit.mockspresso.quick
 
 import com.episode6.hackit.mockspresso.Mockspresso


### PR DESCRIPTION
Kotlin extension methods improve on what `mockspresso-quick` (and `mockspresso-extend`) was trying to do in every way. 

https://github.com/episode6/mockspresso/pull/32 Added JavaSupport methods that mirror our kotlin extension methods but return plugins, allowing us to share a single api/syntax across java and kotlin.

In order to simplify plugin design and compose-ablity, we are deprecating mockspresso-quick (and eventually mockspresso-extend).