### PR TITLE
[CI] Test dokka on every CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - run: ./gradlew assemble
+      - run: ./gradlew dokka
       - run: ./gradlew check
       - run:
           name: Save test results

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,5 +17,10 @@ node {
   }
 
   gradleRunner.buildAndTest()
+
+  stage('docgen') {
+    gradleRunner.runGradle("docgen", "dokka", false)
+  }
+
   gradleRunner.deploy()
 }


### PR DESCRIPTION
We ran into an issue yesterday where a PR passed tests but actually failed to deploy because dokka was failing. This was made worse because we didn't notice the issue until the release branch had already been cut, and had to fix the issue on the fly, on the release branch.

This PR adds a dokka step to all CI runs on both jenkins and circle, even on feature branches that are not being deployed. This should let us catch these kinds of issues of PRs before they are merged.