### PR TITLE
[DEPRECATE] BasicPlugins concrete MockspressoPlugins

### DIFF
--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
@@ -2,9 +2,9 @@ package com.episode6.hackit.mockspresso.basic.plugin
 
 import com.episode6.hackit.mockspresso.Mockspresso
 import com.episode6.hackit.mockspresso.api.MockspressoPlugin
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectionConfig
 import com.episode6.hackit.mockspresso.basic.plugin.javax.ProviderMaker
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectionConfig
 
 /**
  * Kotlin extensions for mockspresso's basic plugins
@@ -15,7 +15,7 @@ import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspres
  * their shortest constructor.
  */
 @JvmSynthetic
-fun Mockspresso.Builder.injectBySimpleConfig(): Mockspresso.Builder = plugin(SimpleInjectMockspressoPlugin())
+fun Mockspresso.Builder.injectBySimpleConfig(): Mockspresso.Builder = injector(SimpleInjectionConfig())
 
 /**
  * Applies the [com.episode6.hackit.mockspresso.api.InjectionConfig] for javax.inject based object creation
@@ -23,7 +23,9 @@ fun Mockspresso.Builder.injectBySimpleConfig(): Mockspresso.Builder = plugin(Sim
  * Also includes special object support for [javax.inject.Provider]s
  */
 @JvmSynthetic
-fun Mockspresso.Builder.injectByJavaxConfig(): Mockspresso.Builder = plugin(JavaxInjectMockspressoPlugin())
+fun Mockspresso.Builder.injectByJavaxConfig(): Mockspresso.Builder = this
+    .injector(JavaxInjectionConfig())
+    .automaticProviders()
 
 /**
  * Adds a [com.episode6.hackit.mockspresso.api.SpecialObjectMaker] to handle [javax.inject.Provider]s

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectMockspressoPlugin.java
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectMockspressoPlugin.java
@@ -5,7 +5,14 @@ import com.episode6.hackit.mockspresso.api.MockspressoPlugin;
 
 /**
  * A Mockspresso Plugin that applies logic to simulate a javax.inject compatible DI framework.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `injectByJavaxConfig()` and its
+ * JavaSupport counterpart
+ * {@link com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport#injectByJavaxConfig()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class JavaxInjectMockspressoPlugin implements MockspressoPlugin {
 
   @Override

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectMockspressoPlugin.java
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectMockspressoPlugin.java
@@ -5,7 +5,14 @@ import com.episode6.hackit.mockspresso.api.MockspressoPlugin;
 
 /**
  * Encapsulates the simplest viable mockspresso components (excluding a mocker).
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `injectBySimpleConfig()` and its
+ * JavaSupport counterpart
+ * {@link com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport#injectBySimpleConfig()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class SimpleInjectMockspressoPlugin implements MockspressoPlugin {
 
   @Override

--- a/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
+++ b/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
@@ -1,9 +1,9 @@
 package com.episode6.hackit.mockspresso.basic.plugin
 
 import com.episode6.hackit.mockspresso.Mockspresso
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectionConfig
 import com.episode6.hackit.mockspresso.basic.plugin.javax.ProviderMaker
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectionConfig
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -23,14 +23,15 @@ class BasicPluginsExtTest {
     val result = builder.injectBySimpleConfig()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).plugin(any<SimpleInjectMockspressoPlugin>())
+    verify(builder).injector(any<SimpleInjectionConfig>())
   }
 
   @Test fun testJavaxPluginSourceOfTruth() {
     val result = builder.injectByJavaxConfig()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).plugin(any<JavaxInjectMockspressoPlugin>())
+    verify(builder).injector(any<JavaxInjectionConfig>())
+    verify(builder).specialObjectMaker(any<ProviderMaker>())
   }
 
   @Test fun testAutomaticProvidersSourceOfTruth() {

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakersMockEverythingTestEasyPowerMockRule.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/rule/CoffeeMakersMockEverythingTestEasyPowerMockRule.java
@@ -3,8 +3,6 @@ package com.episode6.hackit.mockspresso.easymock.powermock.integration.rule;
 import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.easymock.Mock;
@@ -61,7 +59,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRule {
 
   /**
    * Test a simple object with a normal constructor using, using the
-   * {@link SimpleInjectMockspressoPlugin}
+   * simple injector
    */
   @Test
   public void testSimpleCoffeeMaker() {
@@ -74,7 +72,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testConstructorInjectedCoffeeMaker() {
@@ -89,7 +87,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testFieldInjedCoffeeMaker() {
@@ -104,7 +102,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMethodInjectedCoffeeMaker() {
@@ -119,7 +117,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMixedInjectionCoffeeMaker() {

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakersMockEverythingTestEasyPowerMockRunner.java
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/integration/runner/CoffeeMakersMockEverythingTestEasyPowerMockRunner.java
@@ -3,8 +3,6 @@ package com.episode6.hackit.mockspresso.easymock.powermock.integration.runner;
 import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.junit.Before;
@@ -61,7 +59,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRunner {
 
   /**
    * Test a simple object with a normal constructor using, using the
-   * {@link SimpleInjectMockspressoPlugin}
+   * simple injector
    */
   @Test
   public void testSimpleCoffeeMaker() {
@@ -74,7 +72,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testConstructorInjectedCoffeeMaker() {
@@ -89,7 +87,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testFieldInjedCoffeeMaker() {
@@ -104,7 +102,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMethodInjectedCoffeeMaker() {
@@ -119,7 +117,7 @@ public class CoffeeMakersMockEverythingTestEasyPowerMockRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMixedInjectionCoffeeMaker() {

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakersMockEverythingTestEasyMock.java
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/integration/CoffeeMakersMockEverythingTestEasyMock.java
@@ -3,8 +3,6 @@ package com.episode6.hackit.mockspresso.easymock.integration;
 import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
@@ -62,7 +60,7 @@ public class CoffeeMakersMockEverythingTestEasyMock {
 
   /**
    * Test a simple object with a normal constructor using, using the
-   * {@link SimpleInjectMockspressoPlugin}
+   * simple injector
    */
   @Test
   public void testSimpleCoffeeMaker() {
@@ -82,7 +80,7 @@ public class CoffeeMakersMockEverythingTestEasyMock {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testConstructorInjectedCoffeeMaker() {
@@ -97,7 +95,7 @@ public class CoffeeMakersMockEverythingTestEasyMock {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testFieldInjedCoffeeMaker() {
@@ -112,7 +110,7 @@ public class CoffeeMakersMockEverythingTestEasyMock {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMethodInjectedCoffeeMaker() {
@@ -127,7 +125,7 @@ public class CoffeeMakersMockEverythingTestEasyMock {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMixedInjectionCoffeeMaker() {

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakersMockEverythingTestPowerMockitoRule.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/rule/CoffeeMakersMockEverythingTestPowerMockitoRule.java
@@ -3,8 +3,6 @@ package com.episode6.hackit.mockspresso.mockito.powermock.integration.rule;
 import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.junit.Before;
@@ -59,7 +57,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRule {
 
   /**
    * Test a simple object with a normal constructor using, using the
-   * {@link SimpleInjectMockspressoPlugin}
+   * simple injector
    */
   @Test
   public void testSimpleCoffeeMaker() {
@@ -72,7 +70,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testConstructorInjectedCoffeeMaker() {
@@ -87,7 +85,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testFieldInjedCoffeeMaker() {
@@ -102,7 +100,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMethodInjectedCoffeeMaker() {
@@ -117,7 +115,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRule {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMixedInjectionCoffeeMaker() {

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakersMockEverythingTestPowerMockitoRunner.java
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/integration/runner/CoffeeMakersMockEverythingTestPowerMockitoRunner.java
@@ -3,8 +3,6 @@ package com.episode6.hackit.mockspresso.mockito.powermock.integration.runner;
 import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
 import org.junit.Before;
@@ -59,7 +57,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRunner {
 
   /**
    * Test a simple object with a normal constructor using, using the
-   * {@link SimpleInjectMockspressoPlugin}
+   * simple injector
    */
   @Test
   public void testSimpleCoffeeMaker() {
@@ -72,7 +70,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testConstructorInjectedCoffeeMaker() {
@@ -87,7 +85,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testFieldInjedCoffeeMaker() {
@@ -102,7 +100,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMethodInjectedCoffeeMaker() {
@@ -117,7 +115,7 @@ public class CoffeeMakersMockEverythingTestPowerMockitoRunner {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMixedInjectionCoffeeMaker() {

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakersMockEverythingTestMockito.java
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/CoffeeMakersMockEverythingTestMockito.java
@@ -3,8 +3,6 @@ package com.episode6.hackit.mockspresso.mockito.integration;
 import com.episode6.hackit.mockspresso.BuildMockspresso;
 import com.episode6.hackit.mockspresso.Mockspresso;
 import com.episode6.hackit.mockspresso.annotation.RealObject;
-import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspressoPlugin;
-import com.episode6.hackit.mockspresso.basic.plugin.simple.SimpleInjectMockspressoPlugin;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.*;
 import com.episode6.hackit.mockspresso.testing.testobjects.coffee.CoffeeMakers.*;
@@ -60,7 +58,7 @@ public class CoffeeMakersMockEverythingTestMockito {
 
   /**
    * Test a simple object with a normal constructor using, using the
-   * {@link SimpleInjectMockspressoPlugin}
+   * simple injector
    */
   @Test
   public void testSimpleCoffeeMaker() {
@@ -80,7 +78,7 @@ public class CoffeeMakersMockEverythingTestMockito {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testConstructorInjectedCoffeeMaker() {
@@ -95,7 +93,7 @@ public class CoffeeMakersMockEverythingTestMockito {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testFieldInjedCoffeeMaker() {
@@ -110,7 +108,7 @@ public class CoffeeMakersMockEverythingTestMockito {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMethodInjectedCoffeeMaker() {
@@ -125,7 +123,7 @@ public class CoffeeMakersMockEverythingTestMockito {
 
   /**
    * Test an object that is created by javax.inject rules, using the
-   * {@link JavaxInjectMockspressoPlugin}
+   * javax injector
    */
   @Test
   public void testMixedInjectionCoffeeMaker() {


### PR DESCRIPTION
Deprecates the old concrete MockspressoPlugin classes in the basic-plugins module, since our whole api is defined by our extension methods now. Updates our extension methods to perform the impl steps directly so the deprecated stuff is no longer used (except in places that are also getting deprecated in this release).

Also removes mentions of the class name from some comments that aren't going away anytime soon.