### PR TITLE
[DEPRECATE] DaggerMockspressoPlugin in favor of ext func

### DIFF
--- a/mockspresso-dagger/build.gradle
+++ b/mockspresso-dagger/build.gradle
@@ -15,5 +15,6 @@ dependencies {
   testImplementation 'junit:junit'
   testImplementation 'org.easytesting:fest-assert-core'
   testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
+  testImplementation 'io.mockk:mockk'
 }
 

--- a/mockspresso-dagger/build.gradle
+++ b/mockspresso-dagger/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
   implementation project(':mockspresso-basic-plugins')
 
-  mavenProvided 'com.google.dagger:dagger'
+  mavenOptional 'com.google.dagger:dagger'
 
   testImplementation project(':mockspresso-core')
   testImplementation project(':mockspresso-testing-shared')

--- a/mockspresso-dagger/build.gradle
+++ b/mockspresso-dagger/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
   implementation project(':mockspresso-basic-plugins')
 
-  mavenOptional 'com.google.dagger:dagger'
+  mavenProvided 'com.google.dagger:dagger'
 
   testImplementation project(':mockspresso-core')
   testImplementation project(':mockspresso-testing-shared')

--- a/mockspresso-dagger/build.gradle
+++ b/mockspresso-dagger/build.gradle
@@ -15,6 +15,5 @@ dependencies {
   testImplementation 'junit:junit'
   testImplementation 'org.easytesting:fest-assert-core'
   testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin'
-  testImplementation 'io.mockk:mockk'
 }
 

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerMockspressoPlugin.java
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerMockspressoPlugin.java
@@ -7,7 +7,13 @@ import com.episode6.hackit.mockspresso.basic.plugin.javax.JavaxInjectMockspresso
 /**
  * A simple dagger plugin that builds off of the javax injector
  * and adds special object support for {@link dagger.Lazy}
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `injectByDaggerConfig()` and its
+ * JavaSupport counterpart {@link MockspressoDaggerPluginsJavaSupport#injectByDaggerConfig()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class DaggerMockspressoPlugin implements MockspressoPlugin {
   @Override
   public Mockspresso.Builder apply(Mockspresso.Builder builder) {

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
@@ -2,6 +2,7 @@ package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
 import com.episode6.hackit.mockspresso.api.MockspressoPlugin
+import com.episode6.hackit.mockspresso.basic.plugin.injectByJavaxConfig
 
 /**
  * Kotlin extension methods for mockspresso's Dagger plugins
@@ -12,7 +13,9 @@ import com.episode6.hackit.mockspresso.api.MockspressoPlugin
  * with additional support for dagger's Lazy interface.
  */
 @JvmSynthetic
-fun Mockspresso.Builder.injectByDaggerConfig(): Mockspresso.Builder = plugin(DaggerMockspressoPlugin())
+fun Mockspresso.Builder.injectByDaggerConfig(): Mockspresso.Builder = this
+    .injectByJavaxConfig()
+    .automaticLazies()
 
 /**
  * Adds a [com.episode6.hackit.mockspresso.api.SpecialObjectMaker] to handle [dagger.Lazy]s

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
 import com.episode6.hackit.mockspresso.api.MockspressoPlugin
-import com.episode6.hackit.mockspresso.basic.plugin.injectByJavaxConfig
 
 /**
  * Kotlin extension methods for mockspresso's Dagger plugins
@@ -13,9 +12,7 @@ import com.episode6.hackit.mockspresso.basic.plugin.injectByJavaxConfig
  * with additional support for dagger's Lazy interface.
  */
 @JvmSynthetic
-fun Mockspresso.Builder.injectByDaggerConfig(): Mockspresso.Builder = this
-    .injectByJavaxConfig()
-    .automaticLazies()
+fun Mockspresso.Builder.injectByDaggerConfig(): Mockspresso.Builder = plugin(DaggerMockspressoPlugin())
 
 /**
  * Adds a [com.episode6.hackit.mockspresso.api.SpecialObjectMaker] to handle [dagger.Lazy]s

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -3,10 +3,10 @@ package com.episode6.hackit.mockspresso.dagger
 import com.episode6.hackit.mockspresso.Mockspresso
 import com.episode6.hackit.mockspresso.api.InjectionConfig
 import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
+import com.episode6.hackit.mockspresso.testing.className
 import com.nhaarman.mockitokotlin2.*
 import org.fest.assertions.api.Assertions.assertThat
 import org.fest.assertions.api.Assertions.atIndex
-import org.fest.assertions.core.Condition
 import org.junit.Test
 import org.mockito.stubbing.Answer
 
@@ -40,8 +40,4 @@ class DaggerPluginsExtTest {
     assertThat(result).isEqualTo(builder)
     verify(builder).specialObjectMaker(any<DaggerLazyMaker>())
   }
-}
-
-private fun <T: Any> className(simpleName: String) = object : Condition<T>("expected class named $simpleName") {
-  override fun matches(value: T?): Boolean = value!!.javaClass.simpleName == simpleName
 }

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -1,44 +1,32 @@
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
-import com.episode6.hackit.mockspresso.api.MockspressoPlugin
-import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Test
-
+import org.mockito.stubbing.Answer
 
 /**
  * Tests [com.episode6.hackit.mockspresso.dagger.DaggerPluginsExtKt]
  */
 class DaggerPluginsExtTest {
 
-  val builder = mockk<Mockspresso.Builder>().apply {
-    every { plugin(any()) } returns this
-    every { specialObjectMaker(any()) } returns this
-  }
+  val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
 
   @Test
   fun testSimplePluginSourceOfTruth() {
-    val slot = slot<MockspressoPlugin>()
-
     val result = builder.injectByDaggerConfig()
 
     assertThat(result).isEqualTo(builder)
-    verify { builder.plugin(capture(slot)) }
-    assertThat(slot.captured).isInstanceOf(DaggerMockspressoPlugin::class.java)
+    verify(builder).plugin(any<DaggerMockspressoPlugin>())
   }
 
   @Test fun testAutomaticLaziesSourceOfTruth() {
-    val slot = slot<SpecialObjectMaker>()
-
     val result = builder.automaticLazies()
 
     assertThat(result).isEqualTo(builder)
-    verify { builder.specialObjectMaker(capture(slot)) }
-    assertThat(slot.captured).isInstanceOf(DaggerLazyMaker::class.java)
+    verify(builder).specialObjectMaker(any<DaggerLazyMaker>())
   }
 }

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -1,32 +1,44 @@
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
+import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Test
-import org.mockito.stubbing.Answer
+
 
 /**
  * Tests [com.episode6.hackit.mockspresso.dagger.DaggerPluginsExtKt]
  */
 class DaggerPluginsExtTest {
 
-  val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
+  val builder = mockk<Mockspresso.Builder>().apply {
+    every { plugin(any()) } returns this
+    every { specialObjectMaker(any()) } returns this
+  }
 
   @Test
   fun testSimplePluginSourceOfTruth() {
+    val slot = slot<MockspressoPlugin>()
+
     val result = builder.injectByDaggerConfig()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).plugin(any<DaggerMockspressoPlugin>())
+    verify { builder.plugin(capture(slot)) }
+    assertThat(slot.captured).isInstanceOf(DaggerMockspressoPlugin::class.java)
   }
 
   @Test fun testAutomaticLaziesSourceOfTruth() {
+    val slot = slot<SpecialObjectMaker>()
+
     val result = builder.automaticLazies()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).specialObjectMaker(any<DaggerLazyMaker>())
+    verify { builder.specialObjectMaker(capture(slot)) }
+    assertThat(slot.captured).isInstanceOf(DaggerLazyMaker::class.java)
   }
 }

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -1,10 +1,12 @@
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
+import com.episode6.hackit.mockspresso.api.InjectionConfig
+import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
+import com.nhaarman.mockitokotlin2.*
 import org.fest.assertions.api.Assertions.assertThat
+import org.fest.assertions.api.Assertions.atIndex
+import org.fest.assertions.core.Condition
 import org.junit.Test
 import org.mockito.stubbing.Answer
 
@@ -16,11 +18,20 @@ class DaggerPluginsExtTest {
   val builder: Mockspresso.Builder = mock(defaultAnswer = Answer { it.mock })
 
   @Test
-  fun testSimplePluginSourceOfTruth() {
+  fun testInjectByDaggerSourceOfTruth() {
     val result = builder.injectByDaggerConfig()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).plugin(any<DaggerMockspressoPlugin>())
+    argumentCaptor<InjectionConfig>() {
+      verify(builder).injector(capture())
+      assertThat(firstValue).has(className("JavaxInjectionConfig"))
+    }
+    argumentCaptor<SpecialObjectMaker>() {
+      verify(builder, times(2)).specialObjectMaker(capture())
+      assertThat(allValues)
+          .has(className("ProviderMaker"), atIndex(0))
+          .has(className("DaggerLazyMaker"), atIndex(1))
+    }
   }
 
   @Test fun testAutomaticLaziesSourceOfTruth() {
@@ -29,4 +40,8 @@ class DaggerPluginsExtTest {
     assertThat(result).isEqualTo(builder)
     verify(builder).specialObjectMaker(any<DaggerLazyMaker>())
   }
+}
+
+private fun <T: Any> className(simpleName: String) = object : Condition<T>("expected class named $simpleName") {
+  override fun matches(value: T?): Boolean = value!!.javaClass.simpleName == simpleName
 }

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -1,12 +1,13 @@
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
+import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
-import com.episode6.hackit.mockspresso.basic.plugin.injectByJavaxConfig
-import io.mockk.*
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
 import org.fest.assertions.api.Assertions.assertThat
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 
 
@@ -15,31 +16,20 @@ import org.junit.Test
  */
 class DaggerPluginsExtTest {
 
-  lateinit var builder: Mockspresso.Builder
-
-  @Before fun setup() {
-    mockkStatic("com.episode6.hackit.mockspresso.basic.plugin.BasicPluginsExtKt")
-    builder = mockk<Mockspresso.Builder>(relaxed = true).apply {
-      every { injector(any()) } returns this
-      every { specialObjectMaker(any()) } returns this
-    }
-    every { mockk<Mockspresso.Builder>().injectByJavaxConfig() } returns builder
-  }
-
-  @After fun teardown() {
-    unmockkAll()
+  val builder = mockk<Mockspresso.Builder>().apply {
+    every { plugin(any()) } returns this
+    every { specialObjectMaker(any()) } returns this
   }
 
   @Test
   fun testSimplePluginSourceOfTruth() {
-    val slot = slot<SpecialObjectMaker>()
+    val slot = slot<MockspressoPlugin>()
 
     val result = builder.injectByDaggerConfig()
 
     assertThat(result).isEqualTo(builder)
-    verify { builder.injectByJavaxConfig() }
-    verify { builder.specialObjectMaker(capture(slot)) }
-    assertThat(slot.captured).isInstanceOf(DaggerLazyMaker::class.java)
+    verify { builder.plugin(capture(slot)) }
+    assertThat(slot.captured).isInstanceOf(DaggerMockspressoPlugin::class.java)
   }
 
   @Test fun testAutomaticLaziesSourceOfTruth() {

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -1,13 +1,12 @@
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso
-import com.episode6.hackit.mockspresso.api.MockspressoPlugin
 import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.slot
-import io.mockk.verify
+import com.episode6.hackit.mockspresso.basic.plugin.injectByJavaxConfig
+import io.mockk.*
 import org.fest.assertions.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 
 
@@ -16,20 +15,31 @@ import org.junit.Test
  */
 class DaggerPluginsExtTest {
 
-  val builder = mockk<Mockspresso.Builder>().apply {
-    every { plugin(any()) } returns this
-    every { specialObjectMaker(any()) } returns this
+  lateinit var builder: Mockspresso.Builder
+
+  @Before fun setup() {
+    mockkStatic("com.episode6.hackit.mockspresso.basic.plugin.BasicPluginsExtKt")
+    builder = mockk<Mockspresso.Builder>(relaxed = true).apply {
+      every { injector(any()) } returns this
+      every { specialObjectMaker(any()) } returns this
+    }
+    every { mockk<Mockspresso.Builder>().injectByJavaxConfig() } returns builder
+  }
+
+  @After fun teardown() {
+    unmockkAll()
   }
 
   @Test
   fun testSimplePluginSourceOfTruth() {
-    val slot = slot<MockspressoPlugin>()
+    val slot = slot<SpecialObjectMaker>()
 
     val result = builder.injectByDaggerConfig()
 
     assertThat(result).isEqualTo(builder)
-    verify { builder.plugin(capture(slot)) }
-    assertThat(slot.captured).isInstanceOf(DaggerMockspressoPlugin::class.java)
+    verify { builder.injectByJavaxConfig() }
+    verify { builder.specialObjectMaker(capture(slot)) }
+    assertThat(slot.captured).isInstanceOf(DaggerLazyMaker::class.java)
   }
 
   @Test fun testAutomaticLaziesSourceOfTruth() {

--- a/mockspresso-testing-shared/src/main/java/com/episode6/hackit/mockspresso/testing/TestExt.kt
+++ b/mockspresso-testing-shared/src/main/java/com/episode6/hackit/mockspresso/testing/TestExt.kt
@@ -24,3 +24,7 @@ fun <T : Any> ObjectAssert<T>.satisfies(block: (T) -> Unit): ObjectAssert<T> = m
     return true
   }
 })
+
+fun <T: Any> className(simpleName: String) = object : Condition<T>("expected class named $simpleName") {
+  override fun matches(value: T?): Boolean = value!!.javaClass.simpleName == simpleName
+}


### PR DESCRIPTION
Deprecates our `DaggerMockspressoPlugin` and moves the source of truth to the extension method