### PR TITLE
[DEPRECATE] Easy Mock plugins in favor of ext funcs

### DIFF
--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPlugin.java
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPlugin.java
@@ -9,7 +9,13 @@ import org.powermock.api.easymock.PowerMock;
  * Plugin that applies {@link EasyPowerMockMockerConfig} to enable mockspresso usage with Powermock + EasyMock.
  * This plugin does not apply a PowerMockRule, so the implementer is responsible for either running their
  * test with the PowerMockRunner or applying their own PowerMockRule
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByPowerMock()` and its
+ * JavaSupport counterpart {@link MockspressoEasyPowerMockPluginsJavaSupport#mockByPowerMock()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class EasyPowerMockPlugin implements MockspressoPlugin {
   @Override
   public Mockspresso.Builder apply(Mockspresso.Builder builder) {

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
@@ -2,6 +2,7 @@ package com.episode6.hackit.mockspresso.easymock.powermock
 
 import com.episode6.hackit.mockspresso.Mockspresso
 import com.episode6.hackit.mockspresso.api.MockspressoPlugin
+import org.powermock.modules.junit4.rule.PowerMockRule
 
 /**
  * Kotlin extension methods for mockspresso's Powermock + EasyMock plugins
@@ -18,7 +19,7 @@ import com.episode6.hackit.mockspresso.api.MockspressoPlugin
  * To work around this problem, use powermock's @Mock, @MockNice and @MockStrict annotations instead.
  */
 @JvmSynthetic
-fun Mockspresso.Builder.mockByPowerMock(): Mockspresso.Builder = plugin(EasyPowerMockPlugin())
+fun Mockspresso.Builder.mockByPowerMock(): Mockspresso.Builder = mocker(EasyPowerMockMockerConfig())
 
 /**
  * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] for Powermock + EasyMock AND
@@ -27,7 +28,9 @@ fun Mockspresso.Builder.mockByPowerMock(): Mockspresso.Builder = plugin(EasyPowe
  * PLUS org.powermock:powermock-module-junit4-rule and org.powermock:powermock-classloading-xstream
  */
 @JvmSynthetic
-fun Mockspresso.Builder.mockByPowerMockRule(): Mockspresso.Builder = plugin(EasyPowerMockRulePlugin())
+fun Mockspresso.Builder.mockByPowerMockRule(): Mockspresso.Builder = this
+    .mockByPowerMock()
+    .outerRule(PowerMockRule())
 
 /**
  * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockRulePlugin.java
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockRulePlugin.java
@@ -7,7 +7,13 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 /**
  * Plugin that applies {@link EasyPowerMockMockerConfig} AND applies a PowerMockRule as an outer rule
  * to Mockspresso. Use this plugin if you want to use PowerMock without applying the PowerMockRunner
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByPowerMockRule()` and its
+ * JavaSupport counterpart {@link MockspressoEasyPowerMockPluginsJavaSupport#mockByPowerMockRule()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class EasyPowerMockRulePlugin implements MockspressoPlugin {
   @Override
   public Mockspresso.Builder apply(Mockspresso.Builder builder) {

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExtTest.kt
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExtTest.kt
@@ -7,6 +7,7 @@ import org.easymock.Mock
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.powermock.modules.junit4.rule.PowerMockRule
 
 /**
  * Tests [com.episode6.hackit.mockspresso.easymock.EasyMockPluginsExtKt]
@@ -21,7 +22,7 @@ class EasyPowerMockPluginsExtTest {
   }
 
   @Test fun testPowerEasyMockExtensionSourceOfTruth() {
-    expect(builder.plugin(anyObject(EasyPowerMockPlugin::class.java))).andReturn(builder)
+    expect(builder.mocker(anyObject(EasyPowerMockMockerConfig::class.java))).andReturn(builder)
     replay(builder)
 
     val result = builder.mockByPowerMock()
@@ -33,7 +34,8 @@ class EasyPowerMockPluginsExtTest {
   }
 
   @Test fun testPowerEasyMockRuleExtensionSourceOfTruth() {
-    expect(builder.plugin(anyObject(EasyPowerMockRulePlugin::class.java))).andReturn(builder)
+    expect(builder.mocker(anyObject(EasyPowerMockMockerConfig::class.java))).andReturn(builder)
+    expect(builder.outerRule(anyObject(PowerMockRule::class.java))).andReturn(builder)
     replay(builder)
 
     val result = builder.mockByPowerMockRule()

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPlugin.java
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPlugin.java
@@ -6,7 +6,13 @@ import org.easymock.EasyMock;
 
 /**
  * An implementation of MockspressoPlugin that applies the Easy mock mocker config
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByEasyMock()` and its
+ * JavaSupport counterpart {@link MockspressoEasyMockPluginsJavaSupport#mockByEasyMock()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class EasyMockPlugin implements MockspressoPlugin {
   @Override
   public Mockspresso.Builder apply(Mockspresso.Builder builder) {

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
@@ -11,7 +11,7 @@ import com.episode6.hackit.mockspresso.api.MockspressoPlugin
  * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] to support EasyMock
  */
 @JvmSynthetic
-fun Mockspresso.Builder.mockByEasyMock(): Mockspresso.Builder = plugin(EasyMockPlugin())
+fun Mockspresso.Builder.mockByEasyMock(): Mockspresso.Builder = mocker(EasyMockMockerConfig())
 
 /**
  * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExtTest.kt
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExtTest.kt
@@ -21,7 +21,7 @@ class EasyMockPluginsExtTest {
   }
 
   @Test fun testEasyMockExtensionSourceOfTruth() {
-    expect(builder.plugin(anyObject(EasyMockPlugin::class.java))).andReturn(builder)
+    expect(builder.mocker(anyObject(EasyMockMockerConfig::class.java))).andReturn(builder)
     replay(builder)
 
     val result = builder.mockByEasyMock()


### PR DESCRIPTION
Deprecates the following plugins in favor of their kotlin extensions methods (and moves the source of truth)
- `EasyMockPlugin`
- `EasyPowerMockPlugin`
- `EasyPowerMockRulePlugin`