### PR TITLE
[DEPRECATE] GuavaMockspressoPlugin in favor of extension functions

### DIFF
--- a/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaMockspressoPlugin.java
+++ b/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaMockspressoPlugin.java
@@ -6,8 +6,12 @@ import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 
 /**
- *
+ * @deprecated This functionality is now exposed by the kotlin extension methods
+ * `automaticListenableFutures()` and `automaticSuppliers()` and their JavaSupport
+ * counterparts {@link MockspressoGuavaPluginsJavaSupport#automaticListenableFutures()}
+ * and {@link MockspressoGuavaPluginsJavaSupport#automaticSuppliers()}
  */
+@Deprecated
 public class GuavaMockspressoPlugin implements MockspressoPlugin {
   @Override
   public Mockspresso.Builder apply(Mockspresso.Builder builder) {


### PR DESCRIPTION
This plugin is only used in tests and mockspresso-quick now, so no need to update the source of truth.