### PR TITLE
[DEPRECATE] MockitoPlugin in favor of kotlin ext funcs

### DIFF
--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPlugin.java
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPlugin.java
@@ -6,7 +6,13 @@ import org.mockito.Mockito;
 
 /**
  * A MockspressoPlugin that applies the mockito mocker config.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByMockito()` and its
+ * JavaSupport counterpart {@link MockspressoMockitoPluginsJavaSupport#mockByMockito()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class MockitoPlugin implements MockspressoPlugin {
   @Override
   public Mockspresso.Builder apply(Mockspresso.Builder builder) {

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.KClass
  * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] to support mockito
  */
 @JvmSynthetic
-fun Mockspresso.Builder.mockByMockito(): Mockspresso.Builder = plugin(MockitoPlugin())
+fun Mockspresso.Builder.mockByMockito(): Mockspresso.Builder = mocker(MockitoMockerConfig())
 
 /**
  * Applies special object handling for the provided factory classes. The

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
@@ -22,7 +22,7 @@ class MockitoPluginsExtTest {
     val result = builder.mockByMockito()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).plugin(any<MockitoPlugin>())
+    verify(builder).mocker(any<MockitoMockerConfig>())
   }
 
   @Test fun testAutomaticFactorySourceOfTruthKotlin() {


### PR DESCRIPTION
Deprecate the MockitoPlugin in favor of kotlin extension functions and update the source of truth.