### PR TITLE
[DEPRECATE] PowerMockitoPlugin and RulePlugin in favor of ext funcs

### DIFF
--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPlugin.java
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPlugin.java
@@ -9,7 +9,13 @@ import org.powermock.api.mockito.PowerMockito;
  * Plugin that applies {@link PowerMockitoConfig} to enable mockspresso usage with Powermock + Mockito.
  * This plugin does not apply a PowerMockRule, so the implementer is responsible for either running their
  * test with the PowerMockRunner or applying their own PowerMockRule
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByPowerMockito()` and its
+ * JavaSupport counterpart {@link MockspressoPowerMockitoPluginsJavaSupport#mockByPowerMockito()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class PowerMockitoPlugin implements MockspressoPlugin {
 
   @Override

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
@@ -14,7 +14,7 @@ import com.episode6.hackit.mockspresso.api.MockspressoPlugin
  * Also requires your test be runWith the [org.powermock.modules.junit4.PowerMockRunner]
  */
 @JvmSynthetic
-fun Mockspresso.Builder.mockByPowerMockito(): Mockspresso.Builder = plugin(PowerMockitoPlugin())
+fun Mockspresso.Builder.mockByPowerMockito(): Mockspresso.Builder = mocker(PowerMockitoConfig())
 
 /**
  * Applies the [com.episode6.hackit.mockspresso.api.MockerConfig] for Powermock + Mockito
@@ -23,7 +23,9 @@ fun Mockspresso.Builder.mockByPowerMockito(): Mockspresso.Builder = plugin(Power
  * PLUS org.powermock:powermock-module-junit4-rule and org.powermock:powermock-classloading-xstream
  */
 @JvmSynthetic
-fun Mockspresso.Builder.mockByPowerMockitoRule(): Mockspresso.Builder = plugin(PowerMockitoRulePlugin())
+fun Mockspresso.Builder.mockByPowerMockitoRule(): Mockspresso.Builder = this
+    .mockByPowerMockito()
+    .outerRule(org.powermock.modules.junit4.rule.PowerMockRule())
 
 /**
  * Expose the extension methods defined here as [MockspressoPlugin]s for consumption by java tests

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoRulePlugin.java
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoRulePlugin.java
@@ -7,7 +7,13 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 /**
  * Plugin that applies {@link PowerMockitoConfig} AND applies a PowerMockRule as an outer rule
  * to Mockspresso. Use this plugin if you want to use PowerMock without applying the PowerMockRunner
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByPowerMockitoRule()` and its
+ * JavaSupport counterpart {@link MockspressoPowerMockitoPluginsJavaSupport#mockByPowerMockitoRule()}
+ *
+ * This class will be removed in a future release
  */
+@Deprecated
 public class PowerMockitoRulePlugin implements MockspressoPlugin {
   @Override
   public Mockspresso.Builder apply(Mockspresso.Builder builder) {

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExtTest.kt
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExtTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockitokotlin2.verify
 import org.fest.assertions.api.Assertions.assertThat
 import org.junit.Test
 import org.mockito.stubbing.Answer
+import org.powermock.modules.junit4.rule.PowerMockRule
 
 /**
  * Tests [com.episode6.hackit.mockspresso.mockito.powermock.PowerMockitoPluginsExtKt]
@@ -20,7 +21,7 @@ class PowerMockitoPluginsExtTest {
     val result = builder.mockByPowerMockito()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).plugin(any<PowerMockitoPlugin>())
+    verify(builder).mocker(any<PowerMockitoConfig>())
   }
 
   @Test
@@ -28,6 +29,7 @@ class PowerMockitoPluginsExtTest {
     val result = builder.mockByPowerMockitoRule()
 
     assertThat(result).isEqualTo(builder)
-    verify(builder).plugin(any<PowerMockitoRulePlugin>())
+    verify(builder).mocker(any<PowerMockitoConfig>())
+    verify(builder).outerRule(any<PowerMockRule>())
   }
 }


### PR DESCRIPTION
Deprecates our two power mockito plugins in favor of their kotlin extension methods