### PR TITLE
[DEPRECATE] All internal implementations in plugin modules

### DIFF
--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.basic.plugin
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectionConfig.java
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectionConfig.java
@@ -15,7 +15,14 @@ import java.util.List;
  * With this config, we look for the constructor annotated with @Inject, and prefer it.
  * If no @Inject constructor is found, we will use and empty constructor, if one is found.
  * If multiple @Inject constructors are found, an exception will be thrown.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `injectByJavaxConfig()` and its
+ * JavaSupport counterpart
+ * {@link com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport#injectByJavaxConfig()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class JavaxInjectionConfig implements InjectionConfig {
 
   private static final List<Class<? extends Annotation>> INJECT_ANNOTATION = Collections.<Class<? extends Annotation>>singletonList(Inject.class);

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/ProviderMaker.java
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/ProviderMaker.java
@@ -11,7 +11,14 @@ import java.lang.reflect.Type;
 
 /**
  * An implementation of SpecialObjectMaker for {@link javax.inject.Provider}.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `automaticProviders()` and its
+ * JavaSupport counterpart
+ * {@link com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport#automaticProviders()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class ProviderMaker implements SpecialObjectMaker {
 
   @Override

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectionConfig.java
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectionConfig.java
@@ -12,7 +12,14 @@ import java.util.List;
 /**
  * A very simple implementation of InjectionConfig. Chooses the constructor with the least number of arguments,
  * and provides no injectable field annotations.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `injectBySimpleConfig()` and its
+ * JavaSupport counterpart
+ * {@link com.episode6.hackit.mockspresso.basic.plugin.MockspressoBasicPluginsJavaSupport#injectBySimpleConfig()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class SimpleInjectionConfig implements InjectionConfig {
 
   private final ConstructorSelector mConstructorSelector = new SimpleConstructorSelector();

--- a/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
+++ b/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/BasicPluginsExtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.basic.plugin
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerLazyMaker.java
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerLazyMaker.java
@@ -11,7 +11,13 @@ import java.lang.reflect.Type;
 
 /**
  * An implementation of SpecialObjectMaker for {@link dagger.Lazy}.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `automaticLazies()` and its
+ * JavaSupport counterpart {@link MockspressoDaggerPluginsJavaSupport#automaticLazies()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class DaggerLazyMaker implements SpecialObjectMaker {
 
   @Override

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
+++ b/mockspresso-dagger/src/test/java/com/episode6/hackit/mockspresso/dagger/DaggerPluginsExtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.dagger
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockFieldPreparer.java
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockFieldPreparer.java
@@ -17,7 +17,12 @@ import java.util.List;
  * expects some mocks/spies to already be initialized (and doesn't touch those).
  *
  * We use {@link PowerMock#createMock(Class)} to create mocks.
+ *
+ * @deprecated This functionality is internal implementation and shouldn't be exposed
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class EasyPowerMockFieldPreparer implements MockerConfig.FieldPreparer {
   @Override
   public void prepareFields(Object objectWithMockFields) {

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockMockMaker.java
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockMockMaker.java
@@ -7,7 +7,12 @@ import org.powermock.api.easymock.PowerMock;
 
 /**
  * A MockMaker for PowerMock + EasyMock
+ *
+ * @deprecated This functionality is internal implementation and shouldn't be exposed
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class EasyPowerMockMockMaker implements MockerConfig.MockMaker {
 
   @SuppressWarnings("unchecked")

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockMockerConfig.java
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockMockerConfig.java
@@ -11,7 +11,13 @@ import java.util.List;
 
 /**
  * A MockerConfig for PowerMock + EasyMock
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByPowerMock()` and its
+ * JavaSupport counterpart {@link MockspressoEasyPowerMockPluginsJavaSupport#mockByPowerMock()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class EasyPowerMockMockerConfig implements MockerConfig {
 
   private final EasyPowerMockMockMaker mMockMaker = new EasyPowerMockMockMaker();

--- a/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
+++ b/mockspresso-easymock-powermock/src/main/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.easymock.powermock
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExtTest.kt
+++ b/mockspresso-easymock-powermock/src/test/java/com/episode6/hackit/mockspresso/easymock/powermock/EasyPowerMockPluginsExtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.easymock.powermock
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockFieldPreparer.java
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockFieldPreparer.java
@@ -5,7 +5,12 @@ import org.easymock.EasyMockSupport;
 
 /**
  * A FieldPreparer for EasyMock
+ *
+ * @deprecated This functionality is internal implementation and shouldn't be exposed
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class EasyMockFieldPreparer implements MockerConfig.FieldPreparer {
   @Override
   public void prepareFields(Object objectWithMockFields) {

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockMockMaker.java
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockMockMaker.java
@@ -6,7 +6,12 @@ import org.easymock.EasyMock;
 
 /**
  * A MockMaker for EasyMock
+ *
+ * @deprecated This functionality is internal implementation and shouldn't be exposed
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class EasyMockMockMaker implements MockerConfig.MockMaker {
 
   @SuppressWarnings("unchecked")

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockMockerConfig.java
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockMockerConfig.java
@@ -9,7 +9,13 @@ import java.util.List;
 
 /**
  * A MockerConfig for EasyMock
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByEasyMock()` and its
+ * JavaSupport counterpart {@link MockspressoEasyMockPluginsJavaSupport#mockByEasyMock()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class EasyMockMockerConfig implements MockerConfig {
 
   private final EasyMockMockMaker mMockMaker = new EasyMockMockMaker();

--- a/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
+++ b/mockspresso-easymock/src/main/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.easymock
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExtTest.kt
+++ b/mockspresso-easymock/src/test/java/com/episode6/hackit/mockspresso/easymock/EasyMockPluginsExtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.easymock
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExt.kt
+++ b/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.guava
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/ListenableFutureMaker.java
+++ b/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/ListenableFutureMaker.java
@@ -14,7 +14,13 @@ import java.lang.reflect.Type;
  * Special object maker for guava's {@link ListenableFuture}. Uses param type
  * and ident annotation to look up actual dependency, and returns an immediate
  * future.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `automaticListenableFutures()` and its
+ * JavaSupport counterpart {@link MockspressoGuavaPluginsJavaSupport#automaticListenableFutures()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class ListenableFutureMaker implements SpecialObjectMaker {
   @Override
   public boolean canMakeObject(DependencyKey<?> key) {

--- a/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/SupplierMaker.java
+++ b/mockspresso-guava/src/main/java/com/episode6/hackit/mockspresso/guava/SupplierMaker.java
@@ -12,7 +12,13 @@ import java.lang.reflect.Type;
 
 /**
  * Special object handling for guava's {@link Supplier}
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `automaticSuppliers()` and its
+ * JavaSupport counterpart {@link MockspressoGuavaPluginsJavaSupport#automaticSuppliers()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class SupplierMaker implements SpecialObjectMaker {
   @Override
   public boolean canMakeObject(DependencyKey<?> key) {

--- a/mockspresso-guava/src/test/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExtTest.kt
+++ b/mockspresso-guava/src/test/java/com/episode6/hackit/mockspresso/guava/GuavaPluginsExtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.guava
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoConfig.java
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoConfig.java
@@ -10,7 +10,13 @@ import java.util.List;
 
 /**
  * A MockerConfig for Powermock + Mockito
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByPowerMockito()` and its
+ * JavaSupport counterpart {@link MockspressoPowerMockitoPluginsJavaSupport#mockByPowerMockito()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class PowerMockitoConfig implements MockerConfig {
 
   private final MockMaker mMockMaker = new PowerMockitoMockMaker();

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoFieldPreparer.java
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoFieldPreparer.java
@@ -18,7 +18,12 @@ import java.util.List;
  *
  * We use {@link PowerMockito#mock(Class)} to create mocks and {@link Mockito#spy(Object)}/{@link Mockito#spy(Class)}
  * to create spies.
+ *
+ * @deprecated This functionality is internal and should not be exposed.
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class PowerMockitoFieldPreparer implements MockerConfig.FieldPreparer {
 
   @Override

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoMockMaker.java
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoMockMaker.java
@@ -6,7 +6,12 @@ import org.powermock.api.mockito.PowerMockito;
 
 /**
  * Creates generic Powermock mocks
+ *
+ * @deprecated This functionality is internal and should not be exposed.
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class PowerMockitoMockMaker implements MockerConfig.MockMaker {
   @Override
   @SuppressWarnings("unchecked")

--- a/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
+++ b/mockspresso-mockito-powermock/src/main/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.mockito.powermock
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExtTest.kt
+++ b/mockspresso-mockito-powermock/src/test/java/com/episode6/hackit/mockspresso/mockito/powermock/PowerMockitoPluginsExtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.mockito.powermock
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoAutoFactoryMaker.java
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoAutoFactoryMaker.java
@@ -24,9 +24,16 @@ import java.util.List;
  * return type (and the factory's optional qualifier annotation).
  *
  * This class should support most generic factory types.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `automaticFactories(vararg KClass)` and its
+ * JavaSupport counterpart {@link MockspressoMockitoPluginsJavaSupport#automaticFactories(Class[])}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class MockitoAutoFactoryMaker implements SpecialObjectMaker {
 
+  @Deprecated
   public static MockitoAutoFactoryMaker create(Class<?>... classes) {
     return new MockitoAutoFactoryMaker(Arrays.asList(classes));
   }

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoFieldPreparer.java
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoFieldPreparer.java
@@ -5,7 +5,11 @@ import org.mockito.MockitoAnnotations;
 
 /**
  *
+ * @deprecated This functionality is internal and should not be exposed.
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class MockitoFieldPreparer implements MockerConfig.FieldPreparer {
 
   @Override

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoMockMaker.java
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoMockMaker.java
@@ -6,7 +6,12 @@ import org.mockito.Mockito;
 
 /**
  * A {@link com.episode6.hackit.mockspresso.api.MockerConfig.MockMaker} for Mockito
+ *
+ * @deprecated This functionality is internal and should not be exposed.
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class MockitoMockMaker implements MockerConfig.MockMaker {
 
   @SuppressWarnings("unchecked")

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoMockerConfig.java
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoMockerConfig.java
@@ -10,7 +10,13 @@ import java.util.List;
 
 /**
  * A MockerConfig for Mockito.
+ *
+ * @deprecated This functionality is now exposed by the kotlin extension method `mockByMockito()` and its
+ * JavaSupport counterpart {@link MockspressoMockitoPluginsJavaSupport#mockByMockito()}
+ *
+ * This class will be marked internal/protected in a future release
  */
+@Deprecated
 public class MockitoMockerConfig implements MockerConfig {
 
   private final MockitoMockMaker mMockMaker = new MockitoMockMaker();

--- a/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
+++ b/mockspresso-mockito/src/main/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExt.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.mockito
 
 import com.episode6.hackit.mockspresso.Mockspresso

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/MockitoPluginsExtTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.episode6.hackit.mockspresso.mockito
 
 import com.episode6.hackit.mockspresso.Mockspresso


### PR DESCRIPTION
Deprecates all our internal plugin classes, making our only "legal" exposure point out kotlin extension functions and JavaSupport objects