### PR TITLE
[FEATURE] Introduce teardown support for on-the-fly instances

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ### v0.2.0 - unreleased
-
+ - **FEATURE** Introduce a public `teardown()` method for on-the-fly instances
 
 ### v0.1.0 - September 20th, 2020
  - Documentation re-written

--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
@@ -73,6 +73,12 @@ public interface Mockspresso {
   @NotNull Builder buildUpon();
 
   /**
+   * Tears down this on-the-fly mockspresso instance.
+   * Throws exceptions when called on {@link Mockspresso.Rule}s, since they're life-cycle is managed by junit.
+   */
+  void teardown();
+
+  /**
    * An implementation of Mockspresso that also implements JUnit's {@link MethodRule}.
    */
   interface Rule extends Mockspresso, MethodRule {}

--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/Mockspresso.java
@@ -74,7 +74,7 @@ public interface Mockspresso {
 
   /**
    * Tears down this on-the-fly mockspresso instance.
-   * Throws exceptions when called on {@link Mockspresso.Rule}s, since they're life-cycle is managed by junit.
+   * Throws exceptions when called on {@link Mockspresso.Rule}s, since their life-cycle is managed by junit.
    */
   void teardown();
 

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspresso.java
@@ -30,7 +30,7 @@ abstract class AbstractDelayedMockspresso implements Mockspresso, MockspressoInt
   synchronized void setDelegate(@Nullable MockspressoInternal delegate) {
     if (mDelegate != null) {
       passParentToDelayedBuilders(null);
-      mDelegate.getConfig().teardown();
+      mDelegate.teardown();
     }
 
     mDelegate = delegate;
@@ -89,6 +89,11 @@ abstract class AbstractDelayedMockspresso implements Mockspresso, MockspressoInt
     DelayedMockspressoBuilder delayedBuilder = new DelayedMockspressoBuilder(mBuilderProvider);
     mDelayedBuilders.add(delayedBuilder);
     return delayedBuilder;
+  }
+
+  @Override
+  public void teardown() {
+    setDelegate(null);
   }
 
   @Override

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoImpl.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoImpl.java
@@ -78,6 +78,11 @@ class MockspressoImpl implements Mockspresso, MockspressoInternal {
   }
 
   @Override
+  public void teardown() {
+    mMockspressoConfigContainer.teardown();
+  }
+
+  @Override
   public MockspressoConfigContainer getConfig() {
     return mMockspressoConfigContainer;
   }

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoRuleImpl.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoRuleImpl.java
@@ -30,6 +30,11 @@ class MockspressoRuleImpl extends AbstractDelayedMockspresso implements Mockspre
     return mRuleConfig.buildRuleChain(new ImplRule()).apply(base, method, target);
   }
 
+  @Override
+  public void teardown() {
+    throw new IllegalArgumentException("Tear down is not available on Mockspresso.Rules, mockspresso will be torn-down automatically by junit.");
+  }
+
   private class ImplRule implements MethodRule {
     @Override
     public Statement apply(final Statement base, FrameworkMethod method, final Object target) {

--- a/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspressoTest.java
+++ b/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/AbstractDelayedMockspressoTest.java
@@ -72,7 +72,7 @@ public class AbstractDelayedMockspressoTest {
     InOrder inOrder = Mockito.inOrder(mConfig, mMockspressoInternal);
     inOrder.verify(mConfig).setup(mMockspressoInternal);
     inOrder.verify(mMockspressoInternal).create(String.class);
-    inOrder.verify(mConfig).teardown();
+    inOrder.verify(mMockspressoInternal).teardown();
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -86,15 +86,15 @@ public class AbstractDelayedMockspressoTest {
     mMockspresso.setDelegate(null);
 
 
-    InOrder inOrder = Mockito.inOrder(mBuilderProvider, mConfig, mChildBuilder, mChildConfig, mChildMockspresso);
+    InOrder inOrder = Mockito.inOrder(mBuilderProvider, mConfig, mChildBuilder, mChildConfig, mChildMockspresso, mMockspressoInternal);
     inOrder.verify(mBuilderProvider).get();
     inOrder.verify(mConfig).setup(mMockspressoInternal);
     inOrder.verify(mChildBuilder).deepCopy();
     inOrder.verify(mChildBuilder).setParent(mConfig);
     inOrder.verify(mChildConfig).setup(mChildMockspresso);
     inOrder.verify(mChildMockspresso).create(TestClass.class);
-    inOrder.verify(mChildConfig).teardown();
-    inOrder.verify(mConfig).teardown();
+    inOrder.verify(mChildMockspresso).teardown();
+    inOrder.verify(mMockspressoInternal).teardown();
     inOrder.verifyNoMoreInteractions();
     verifyZeroInteractions(mPublicBuilder);
   }

--- a/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/DelayedMockspressoBuilderTest.java
+++ b/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/DelayedMockspressoBuilderTest.java
@@ -72,12 +72,12 @@ public class DelayedMockspressoBuilderTest {
     mDelayedBuilder.setParent(mConfig);
     mDelayedBuilder.setParent(null);
 
-    InOrder inOrder = Mockito.inOrder(mBackingBuilder, mConfig, mChildConfig);
+    InOrder inOrder = Mockito.inOrder(mBackingBuilder, mConfig, mChildConfig, mChildMockspresso);
     inOrder.verify(mBackingBuilder).deepCopy();
     inOrder.verify(mBackingBuilder).setParent(mConfig);
     inOrder.verify(mBackingBuilder).buildInternal();
     inOrder.verify(mChildConfig).setup(mChildMockspresso);
-    inOrder.verify(mChildConfig).teardown();
+    inOrder.verify(mChildMockspresso).teardown();
     verifyNoMoreInteractions(mBackingBuilder, mConfig, mChildConfig);
   }
 

--- a/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/MockspressoRuleImplTest.java
+++ b/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/MockspressoRuleImplTest.java
@@ -67,13 +67,13 @@ public class MockspressoRuleImplTest {
     Statement result = mRule.apply(base, mFrameworkMethod, mTarget);
     result.evaluate();
 
-    InOrder inOrder = Mockito.inOrder(mConfig, mBuilderProvider, mBuilder, base, mConfig, mChildConfig);
+    InOrder inOrder = Mockito.inOrder(mConfig, mBuilderProvider, mBuilder, base, mConfig, mChildConfig, mOriginal);
     inOrder.verify(mBuilder).deepCopy();
     inOrder.verify(mBuilder).testResourcesWithoutLifecycle(mTarget);
     inOrder.verify(mBuilder).buildInternal();
     inOrder.verify(mConfig).setup(mOriginal);
     inOrder.verify(base).evaluate();
-    inOrder.verify(mConfig).teardown();
+    inOrder.verify(mOriginal).teardown();
 
     assertRuleNoLongerWorks();
   }
@@ -87,7 +87,7 @@ public class MockspressoRuleImplTest {
     Statement result = mRule.apply(base, mFrameworkMethod, mTarget);
     result.evaluate();
 
-    InOrder inOrder = Mockito.inOrder(mConfig, mBuilderProvider, mBuilder, base, mConfig, mChildConfig, mChildBuilder, mChildMockspresso);
+    InOrder inOrder = Mockito.inOrder(mConfig, mBuilderProvider, mBuilder, base, mConfig, mChildConfig, mChildBuilder, mChildMockspresso, mOriginal);
     inOrder.verify(mBuilderProvider).get();
     inOrder.verify(mBuilder).deepCopy();
     inOrder.verify(mBuilder).testResourcesWithoutLifecycle(mTarget);
@@ -97,8 +97,8 @@ public class MockspressoRuleImplTest {
     inOrder.verify(mChildBuilder).buildInternal();
     inOrder.verify(mChildConfig).setup(mChildMockspresso);
     inOrder.verify(base).evaluate();
-    inOrder.verify(mChildConfig).teardown();
-    inOrder.verify(mConfig).teardown();
+    inOrder.verify(mChildMockspresso).teardown();
+    inOrder.verify(mOriginal).teardown();
 
     assertMockspressoNoLongerWorks(mockspresso);
     assertRuleNoLongerWorks();
@@ -124,6 +124,7 @@ public class MockspressoRuleImplTest {
         mConfig,
         mBuilderProvider,
         mBuilder,
+        mOriginal,
         base,
         mConfig,
         innerRule1,
@@ -154,7 +155,7 @@ public class MockspressoRuleImplTest {
     inOrder.verify(base).evaluate();
     inOrder.verify(innerRule2.returnStatement).after();
     inOrder.verify(innerRule1.returnStatement).after();
-    inOrder.verify(mConfig).teardown();
+    inOrder.verify(mOriginal).teardown();
     inOrder.verify(outerRule2.returnStatement).after();
     inOrder.verify(outerRule1.returnStatement).after();
 
@@ -182,6 +183,8 @@ public class MockspressoRuleImplTest {
         mConfig,
         mBuilderProvider,
         mBuilder,
+        mOriginal,
+        mChildMockspresso,
         base,
         mConfig,
         mChildConfig,
@@ -219,8 +222,8 @@ public class MockspressoRuleImplTest {
     inOrder.verify(base).evaluate();
     inOrder.verify(innerRule2.returnStatement).after();
     inOrder.verify(innerRule1.returnStatement).after();
-    inOrder.verify(mChildConfig).teardown();
-    inOrder.verify(mConfig).teardown();
+    inOrder.verify(mChildMockspresso).teardown();
+    inOrder.verify(mOriginal).teardown();
     inOrder.verify(outerRule2.returnStatement).after();
     inOrder.verify(outerRule1.returnStatement).after();
 

--- a/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
+++ b/mockspresso-extend/src/main/java/com/episode6/hackit/mockspresso/extend/AbstractMockspressoExtension.java
@@ -80,6 +80,11 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
     return mBuilderWrapper.wrap(mDelegate.buildUpon());
   }
 
+  @Override
+  public void teardown() {
+    mDelegate.teardown();
+  }
+
   /**
    * Extend this abstract class for a custom implementation of the {@link Mockspresso.Rule} interface.
    * In the subclass of {@link AbstractMockspressoExtension.Rule}, you should only need to override the constructor, providing
@@ -130,6 +135,11 @@ public abstract class AbstractMockspressoExtension<BLDR extends MockspressoExten
     @Override
     public BLDR buildUpon() {
       return mBuilderWrapper.wrap(mDelegate.buildUpon());
+    }
+
+    @Override
+    public void teardown() {
+      mDelegate.teardown();
     }
 
     @Override

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/LifecycleRuleTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/LifecycleRuleTest.kt
@@ -1,0 +1,42 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
+import org.fest.assertions.api.Assertions.assertThat
+import org.fest.assertions.api.Assertions.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LifecycleRuleTest {
+
+  private val testRes = LifecycleTestResources()
+
+  @get:Rule val mockspresso = BuildMockspresso.with()
+      .injectBySimpleConfig()
+      .mockByMockito()
+      .testResources(testRes)
+      .buildRule()
+
+  @Test fun testLifecycleRule() {
+
+    with(testRes) {
+      assertThat(isSetup).isTrue
+      assertThat(isTornDown).isFalse
+    }
+  }
+
+  @Test fun testTeardownException() {
+    try {
+      mockspresso.teardown()
+    } catch (e: IllegalArgumentException) {
+      // expected
+      return
+    }
+    fail("Expected an IllegalArgumentException")
+  }
+
+}

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/LifecycleTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/LifecycleTest.kt
@@ -1,0 +1,62 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
+import com.nhaarman.mockitokotlin2.mock
+import org.fest.assertions.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LifecycleTest {
+
+  @Test fun testLifecycleOnTheFly() {
+    val testRes = LifecycleTestResources()
+
+    with(testRes) {
+      assertThat(isSetup).isFalse
+      assertThat(isTornDown).isFalse
+    }
+
+    val mockspresso = BuildMockspresso.with()
+        .injectBySimpleConfig()
+        .mockByMockito()
+        .testResources(testRes)
+        .build()
+
+    with(testRes) {
+      assertThat(isSetup).isTrue
+      assertThat(isTornDown).isFalse
+    }
+
+    mockspresso.teardown()
+
+    with(testRes) {
+      assertThat(isSetup).isTrue
+      assertThat(isTornDown).isTrue
+    }
+  }
+
+  @Test fun testRuleLifecycle() {
+    val testRes = LifecycleTestResources()
+    val mockspresso = BuildMockspresso.with()
+        .injectBySimpleConfig()
+        .mockByMockito()
+        .testResources(testRes)
+        .buildRule()
+
+    with(testRes) {
+      assertThat(isSetup).isFalse
+      assertThat(isTornDown).isFalse
+    }
+
+    mockspresso.apply(mock(), mock(), mock()).evaluate()
+
+    with(testRes) {
+      assertThat(isSetup).isTrue
+      assertThat(isTornDown).isTrue
+    }
+  }
+}

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/LifecycleTestResources.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/LifecycleTestResources.kt
@@ -1,0 +1,19 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import org.junit.After
+import org.junit.Before
+
+internal class LifecycleTestResources {
+  var isSetup: Boolean = false
+  var isTornDown: Boolean = false
+
+  @Before
+  fun setup() {
+    isSetup = true
+  }
+
+  @After
+  fun teardown() {
+    isTornDown = true
+  }
+}


### PR DESCRIPTION
Introduces a public `teardown()` method to Mockspresso. Currently this only actually tears down any existing life-cycle components (i.e. testResources with `@After` methods), but in a follow up PR we will add teardown support for mockers (and maybe injectors) as well.