### PR TITLE
[UTIL] Add DependencyKey.isParameterizedGeneric

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
  - **DEPRECATED** `mockspresso-extend` module in favor of kotlin.
  - **REMOVED** `mockspresso-quick` module
  - **FEATURE** Introduce a public `teardown()` method for on-the-fly instances
+ - **UTIL** Added kotlin extensions `DependencyKey.isParameterizedGeneric` and `DependencyKey.genericParameterKey` to simplify common special object maker implementations.
 
 ### v0.1.0 - September 20th, 2020
  - Documentation re-written

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/ProviderMaker.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/ProviderMaker.kt
@@ -4,16 +4,14 @@ import com.episode6.hackit.mockspresso.api.DependencyProvider
 import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
 import com.episode6.hackit.mockspresso.reflect.DependencyKey
 import com.episode6.hackit.mockspresso.reflect.genericParameterKey
-import java.lang.reflect.ParameterizedType
+import com.episode6.hackit.mockspresso.reflect.isParameterizedGeneric
 import javax.inject.Provider
 
 /**
  * An implementation of SpecialObjectMaker for [javax.inject.Provider].
  */
 internal class ProviderMaker : SpecialObjectMaker {
-  override fun canMakeObject(key: DependencyKey<*>): Boolean =
-      key.typeToken.rawType == Provider::class.java &&
-          key.typeToken.type is ParameterizedType
+  override fun canMakeObject(key: DependencyKey<*>): Boolean = key.isParameterizedGeneric(Provider::class)
 
   @Suppress("UNCHECKED_CAST")
   override fun <T> makeObject(dependencyProvider: DependencyProvider, key: DependencyKey<T>): T? {

--- a/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerLazyMaker.kt
+++ b/mockspresso-dagger/src/main/java/com/episode6/hackit/mockspresso/dagger/DaggerLazyMaker.kt
@@ -3,18 +3,15 @@ package com.episode6.hackit.mockspresso.dagger
 import com.episode6.hackit.mockspresso.api.DependencyProvider
 import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
 import com.episode6.hackit.mockspresso.reflect.DependencyKey
-import com.episode6.hackit.mockspresso.reflect.TypeToken
 import com.episode6.hackit.mockspresso.reflect.genericParameterKey
+import com.episode6.hackit.mockspresso.reflect.isParameterizedGeneric
 import dagger.Lazy
-import java.lang.reflect.ParameterizedType
 
 /**
  * An implementation of SpecialObjectMaker for [dagger.Lazy].
  */
 internal class DaggerLazyMaker : SpecialObjectMaker {
-  override fun canMakeObject(key: DependencyKey<*>): Boolean =
-      key.typeToken.rawType == Lazy::class.java &&
-          key.typeToken.type is ParameterizedType
+  override fun canMakeObject(key: DependencyKey<*>): Boolean = key.isParameterizedGeneric(Lazy::class)
 
   @Suppress("UNCHECKED_CAST")
   override fun <T> makeObject(dependencyProvider: DependencyProvider, key: DependencyKey<T>): T? {

--- a/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
+++ b/mockspresso-reflect/src/main/java/com/episode6/hackit/mockspresso/reflect/ReflectExt.kt
@@ -1,6 +1,7 @@
 package com.episode6.hackit.mockspresso.reflect
 
 import java.lang.reflect.ParameterizedType
+import kotlin.reflect.KClass
 
 /**
  * Kotlin extensions for reflection utils using reified type parameters
@@ -18,6 +19,13 @@ inline fun <reified T : Any> typeToken(): TypeToken<T> = object : TypeToken<T>()
  */
 inline fun <reified T : Any> dependencyKey(qualifier: Annotation? = null): DependencyKey<T> =
     DependencyKey.of<T>(typeToken<T>(), qualifier)
+
+/**
+ * return true if the receiver [DependencyKey] represents a parameterized generic of [clazz].
+ * If [clazz] is not generic this method should always return false.
+ */
+fun DependencyKey<*>.isParameterizedGeneric(clazz: KClass<*>): Boolean =
+    typeToken.rawType == clazz.java && typeToken.type is ParameterizedType
 
 /**
  * If the receiver [DependencyKey] represents a parameterized type, this method returns

--- a/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/DependencyKeyKotlinTest.kt
+++ b/mockspresso-reflect/src/test/java/com/episode6/hackit/mockspresso/reflect/DependencyKeyKotlinTest.kt
@@ -93,4 +93,22 @@ class DependencyKeyKotlinTest {
     assertThat(namedParamKey.identityAnnotation).isEqualTo(namedKey.identityAnnotation)
     assertThat(unNamedParamKey.identityAnnotation).isNull()
   }
+
+  @Test fun testIsGenericParam_simpleFail() {
+    val result = dependencyKey<String>().isParameterizedGeneric(Provider::class)
+
+    assertThat(result).isFalse
+  }
+
+  @Test fun testIsGenericParam_sameTypeFail() {
+    val result = DependencyKey.of(Provider::class.java).isParameterizedGeneric(Provider::class)
+
+    assertThat(result).isFalse
+  }
+
+  @Test fun testIsGenericParam_pass() {
+    val result = dependencyKey<Provider<String>>().isParameterizedGeneric(Provider::class)
+
+    assertThat(result).isTrue
+  }
 }


### PR DESCRIPTION
Simplify the `canMakeObject` method for some of our special object makers