### PR TITLE
[InjectionConfig] Remove useless type variable

### DIFF
--- a/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/api/InjectionConfig.kt
+++ b/mockspresso-api/src/main/java/com/episode6/hackit/mockspresso/api/InjectionConfig.kt
@@ -9,5 +9,5 @@ import java.lang.reflect.Constructor
 interface InjectionConfig {
   fun provideInjectableFieldAnnotations(): List<Class<out Annotation>>
   fun provideInjectableMethodAnnotations(): List<Class<out Annotation>>
-  fun <T : Any> chooseConstructor(typeToken: TypeToken<T>): Constructor<T>?
+  fun chooseConstructor(typeToken: TypeToken<*>): Constructor<out Any>?
 }

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectionConfig.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectionConfig.kt
@@ -14,14 +14,12 @@ import javax.inject.Inject
 internal class JavaxInjectionConfig : InjectionConfig {
   override fun provideInjectableFieldAnnotations(): List<Class<out Annotation>> = listOf(Inject::class.java)
   override fun provideInjectableMethodAnnotations(): List<Class<out Annotation>> = listOf(Inject::class.java)
-
-  @Suppress("UNCHECKED_CAST")
-  override fun <T : Any> chooseConstructor(typeToken: TypeToken<T>): Constructor<T>? {
+  override fun chooseConstructor(typeToken: TypeToken<*>): Constructor<out Any>? {
     val injectConstructors = typeToken.rawType.declaredConstructors.filter { it.isAnnotationPresent(Inject::class.java) }
     return when (injectConstructors.size) {
       0    -> typeToken.rawType.declaredConstructors.firstOrNull { it.parameterCount == 0 }
       1    -> injectConstructors[0]
       else -> throw MultipleInjectConstructorException(typeToken)
-    } as Constructor<T>?
+    }
   }
 }

--- a/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectionConfig.kt
+++ b/mockspresso-basic-plugins/src/main/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectionConfig.kt
@@ -11,9 +11,7 @@ import java.lang.reflect.Constructor
 internal class SimpleInjectionConfig : InjectionConfig {
   override fun provideInjectableFieldAnnotations(): List<Class<out Annotation>> = emptyList()
   override fun provideInjectableMethodAnnotations(): List<Class<out Annotation>> = emptyList()
-
-  @Suppress("UNCHECKED_CAST")
-  override fun <T : Any> chooseConstructor(typeToken: TypeToken<T>): Constructor<T>? = typeToken.rawType
+  override fun chooseConstructor(typeToken: TypeToken<*>): Constructor<out Any>? = typeToken.rawType
       .declaredConstructors
-      .minByOrNull { it.parameterCount } as Constructor<T>?
+      .minByOrNull { it.parameterCount }
 }

--- a/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectionConfigTest.java
+++ b/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/javax/JavaxInjectionConfigTest.java
@@ -24,7 +24,7 @@ public class JavaxInjectionConfigTest {
 
   @Test
   public void testFindInjectConstructor() {
-    Constructor<TestClassWithMultipleConstructorsButOnlyOneInject> constructor = mInjectionConfig
+    Constructor<TestClassWithMultipleConstructorsButOnlyOneInject> constructor = (Constructor<TestClassWithMultipleConstructorsButOnlyOneInject>) mInjectionConfig
         .chooseConstructor(TypeToken.of(TestClassWithMultipleConstructorsButOnlyOneInject.class));
 
     assertThat(constructor).isNotNull();
@@ -34,13 +34,13 @@ public class JavaxInjectionConfigTest {
 
   @Test(expected = MultipleInjectConstructorException.class)
   public void testMultipleInjectConstructors() {
-    Constructor<TestClassWithTwoInjectAnnotations> constructor = mInjectionConfig
+    Constructor<TestClassWithTwoInjectAnnotations> constructor = (Constructor<TestClassWithTwoInjectAnnotations>) mInjectionConfig
         .chooseConstructor(TypeToken.of(TestClassWithTwoInjectAnnotations.class));
   }
 
   @Test
   public void testFindFallbackConstructor() {
-    Constructor<TestClassWithEmptyFallback> constructor = mInjectionConfig
+    Constructor<TestClassWithEmptyFallback> constructor = (Constructor<TestClassWithEmptyFallback>) mInjectionConfig
         .chooseConstructor(TypeToken.of(TestClassWithEmptyFallback.class));
 
     assertThat(constructor).isNotNull();
@@ -50,7 +50,7 @@ public class JavaxInjectionConfigTest {
 
   @Test
   public void testNoValidConstructor() {
-    Constructor<TestClassWithNoValidConstructor> constructor = mInjectionConfig
+    Constructor<TestClassWithNoValidConstructor> constructor = (Constructor<TestClassWithNoValidConstructor>) mInjectionConfig
         .chooseConstructor(TypeToken.of(TestClassWithNoValidConstructor.class));
 
     assertThat(constructor).isNull();
@@ -58,7 +58,7 @@ public class JavaxInjectionConfigTest {
 
   @Test
   public void testFindFallbackConstructorWhenNoneDeclared() {
-    Constructor<TestClassWithNoDefinedConstructors> constructor = mInjectionConfig
+    Constructor<TestClassWithNoDefinedConstructors> constructor = (Constructor<TestClassWithNoDefinedConstructors>) mInjectionConfig
         .chooseConstructor(TypeToken.of(TestClassWithNoDefinedConstructors.class));
 
     assertThat(constructor).isNotNull();

--- a/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectionConfigTest.java
+++ b/mockspresso-basic-plugins/src/test/java/com/episode6/hackit/mockspresso/basic/plugin/simple/SimpleInjectionConfigTest.java
@@ -12,15 +12,15 @@ import static org.fest.assertions.api.Assertions.assertThat;
 /**
  * Tests {@link SimpleInjectionConfig}
  */
-public class SimpleInjectionConfigTest {
+@SuppressWarnings("unchecked") public class SimpleInjectionConfigTest {
 
   private SimpleInjectionConfig mSimpleInjectionConfig = new SimpleInjectionConfig();
 
   @Test
   public void testFindSmalledConstructor() {
-    Constructor<TestClass1> constructor1 = mSimpleInjectionConfig
+    Constructor<TestClass1> constructor1 = (Constructor<TestClass1>) mSimpleInjectionConfig
         .chooseConstructor(TypeToken.of(TestClass1.class));
-    Constructor<TestClass2> constructor2 = mSimpleInjectionConfig
+    Constructor<TestClass2> constructor2 = (Constructor<TestClass2>) mSimpleInjectionConfig
         .chooseConstructor(TypeToken.of(TestClass2.class));
 
     assertThat(constructor1.getParameterCount()).isEqualTo(1);
@@ -36,7 +36,7 @@ public class SimpleInjectionConfigTest {
 
   @Test
   public void testFailWithNoConstructor() {
-    Constructor<TestInterface> constructor = mSimpleInjectionConfig
+    Constructor<TestInterface> constructor = (Constructor<TestInterface>) mSimpleInjectionConfig
         .chooseConstructor(TypeToken.of(TestInterface.class));
 
     assertThat(constructor).isNull();

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/RealObjectMaker.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/RealObjectMaker.java
@@ -40,7 +40,7 @@ class RealObjectMaker  {
   }
 
   private <T> T createObjectInternal(DependencyProvider dependencyProvider, TypeToken<T> typeToken) throws IllegalAccessException, InvocationTargetException, InstantiationException {
-    Constructor<T> constructor = mInjectionConfig.chooseConstructor(typeToken);
+    @SuppressWarnings("unchecked") Constructor<T> constructor = (Constructor<T>) mInjectionConfig.chooseConstructor(typeToken);
     if (constructor == null) {
       throw new NoValidConstructorException(typeToken);
     }


### PR DESCRIPTION
The `InjectionConfig`s `chooseConstructor()` method has an unnecessary type variable included since it's impossible to go from a `TypeToken<T>` -> `Constructor<T>` without an unchecked cast. This means that every implementation of `InjectionConfig` must include the same annoying unchecked cast warning.

This PR removes the type variable from `chooseConstructor()` and does the casting internally. This allows for simpler implementations of `InjectionConfig`.