### PR TITLE
[Refactor] Cast special objects in container

### DIFF
--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/DependencyProviderFactory.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/DependencyProviderFactory.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.internal;
 
 import com.episode6.hackit.mockspresso.api.DependencyProvider;
 import com.episode6.hackit.mockspresso.api.MockerConfig;
-import com.episode6.hackit.mockspresso.api.SpecialObjectMaker;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.TypeToken;
 import org.jetbrains.annotations.NotNull;
@@ -25,14 +24,14 @@ class DependencyProviderFactory {
 
   private final MockerConfig.MockMaker mMockMaker;
   private final DependencyMap mDependencyMap;
-  private final SpecialObjectMaker mSpecialObjectMaker;
+  private final SpecialObjectMakerContainer mSpecialObjectMaker;
   private final RealObjectMapping mRealObjectMapping;
   private final RealObjectMaker mRealObjectMaker;
 
   DependencyProviderFactory(
       MockerConfig.MockMaker mockMaker,
       DependencyMap dependencyMap,
-      SpecialObjectMaker specialObjectMaker,
+      SpecialObjectMakerContainer specialObjectMaker,
       RealObjectMapping realObjectMapping,
       RealObjectMaker realObjectMaker) {
     mMockMaker = mockMaker;
@@ -75,8 +74,7 @@ class DependencyProviderFactory {
         return obj;
       }
       if (mSpecialObjectMaker.canMakeObject(key)) {
-        @SuppressWarnings("unchecked") T specialObject = (T) mSpecialObjectMaker.makeObject(childProvider, key);
-        return specialObject;
+        return mSpecialObjectMaker.makeObject(childProvider, key);
       }
       return mMockMaker.makeMock(key.typeToken);
     }

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoConfigContainer.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/MockspressoConfigContainer.java
@@ -2,7 +2,6 @@ package com.episode6.hackit.mockspresso.internal;
 
 import com.episode6.hackit.mockspresso.api.InjectionConfig;
 import com.episode6.hackit.mockspresso.api.MockerConfig;
-import com.episode6.hackit.mockspresso.api.SpecialObjectMaker;
 
 /**
  * Class that holds the internal configuration of a mockspresso instance so that
@@ -13,7 +12,7 @@ class MockspressoConfigContainer {
   private final MockerConfig mMockerConfig;
   private final InjectionConfig mInjectionConfig;
   private final DependencyMap mDependencyMap;
-  private final SpecialObjectMaker mSpecialObjectMaker;
+  private final SpecialObjectMakerContainer mSpecialObjectMaker;
   private final RealObjectMapping mRealObjectMapping;
   private final ResourcesLifecycleManager mResourcesLifecycleManager;
 
@@ -21,7 +20,7 @@ class MockspressoConfigContainer {
       MockerConfig mockerConfig,
       InjectionConfig injectionConfig,
       DependencyMap dependencyMap,
-      SpecialObjectMaker specialObjectMaker,
+      SpecialObjectMakerContainer specialObjectMaker,
       RealObjectMapping realObjectMapping,
       ResourcesLifecycleManager resourcesLifecycleManager) {
     mMockerConfig = mockerConfig;
@@ -44,7 +43,7 @@ class MockspressoConfigContainer {
     return mDependencyMap;
   }
 
-  SpecialObjectMaker getSpecialObjectMaker() {
+  SpecialObjectMakerContainer getSpecialObjectMaker() {
     return mSpecialObjectMaker;
   }
 

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/RealObjectMaker.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/RealObjectMaker.java
@@ -40,7 +40,7 @@ class RealObjectMaker  {
   }
 
   private <T> T createObjectInternal(DependencyProvider dependencyProvider, TypeToken<T> typeToken) throws IllegalAccessException, InvocationTargetException, InstantiationException {
-    @SuppressWarnings("unchecked") Constructor<T> constructor = (Constructor<T>) mInjectionConfig.chooseConstructor(typeToken);
+    @SuppressWarnings("unchecked") Constructor<T> constructor = (Constructor<T>) mInjectionConfig.chooseConstructor(typeToken); // TODO throw custom exception
     if (constructor == null) {
       throw new NoValidConstructorException(typeToken);
     }

--- a/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/DependencyProviderFactoryTest.java
+++ b/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/DependencyProviderFactoryTest.java
@@ -29,7 +29,7 @@ public class DependencyProviderFactoryTest {
 
   @Mock MockerConfig.MockMaker mMockMaker;
   @Mock DependencyMap mDependencyMap;
-  @Mock SpecialObjectMaker mSpecialObjectMaker;
+  @Mock SpecialObjectMakerContainer mSpecialObjectMaker;
   @Mock RealObjectMapping mRealObjectMapping;
   @Mock RealObjectMaker mRealObjectMaker;
 

--- a/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/SpecialObjectMakerContainerTest.java
+++ b/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/SpecialObjectMakerContainerTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 @RunWith(DefaultTestRunner.class)
 public class SpecialObjectMakerContainerTest {
 
-  @Mock SpecialObjectMaker parentMaker;
+  @Mock SpecialObjectMakerContainer parentMaker;
 
   @Mock SpecialObjectMaker specialObjectMaker1;
   @Mock SpecialObjectMaker specialObjectMaker2;


### PR DESCRIPTION
Now that we've removed the need for `SpecialObjectMaker`s to cast to the correct type, we need to be able to throw custom exceptions when the cast of a special object fails that includes the class-name of the maker that provided the incorrect type.

However, because the `SpecialObjectMakerContainer` implements `SpecialObjectMaker` and owns the collection of makers, we can't do that unless we remove the interface and do the casting inside SpecialObjectMakerContainer.

In a follow up PR we will add a new exception & new tests to verify this behavior, this is just a prerequisite.