### PR TITLE
[Fix] Catch ClassCastExceptions in special object container

### DIFF
--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/exception/Exceptions.kt
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/exception/Exceptions.kt
@@ -1,5 +1,6 @@
 package com.episode6.hackit.mockspresso.exception
 
+import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
 import com.episode6.hackit.mockspresso.reflect.DependencyKey
 import com.episode6.hackit.mockspresso.reflect.TypeToken
 
@@ -17,3 +18,9 @@ class NoValidConstructorException(typeToken: TypeToken<*>) : VerifyError("No val
  * Exception thrown when trying multiple fields/objects are bound to the same [DependencyKey] in a single Mockspresso instance.
  */
 class RepeatedDependencyDefinedException(key: DependencyKey<*>) : VerifyError("Dependency defined multiple times in same Mockspresso instance, consider annotating with @Unmapped. DependencyKey: $key")
+
+/**
+ * Thrown when a special object maker returns an object that cannot be cast to the type represented by [key]
+ */
+class BrokenSpecialObjectMakerException(maker: SpecialObjectMaker, key: DependencyKey<*>, value: Any?) : IllegalArgumentException(
+    "Special object maker returned an invalid object. SpecialObjectMaker: ${maker.javaClass.name}, expected: $key, but object returned type: ${value?.javaClass?.name}, value: $value")

--- a/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/SpecialObjectMakerContainerTest.java
+++ b/mockspresso-core/src/test/java/com/episode6/hackit/mockspresso/internal/SpecialObjectMakerContainerTest.java
@@ -28,7 +28,7 @@ public class SpecialObjectMakerContainerTest {
   @Mock SpecialObjectMaker specialObjectMaker2;
   @Mock SpecialObjectMaker specialObjectMaker3;
 
-  @Mock DependencyKey<String> dependencyKey;
+  DependencyKey<String> dependencyKey = DependencyKey.of(String.class);
   @Mock DependencyProvider dependencyProvider;
 
   AutoCloseable mockitoClosable;

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/SpecialObjectCastFailureTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/SpecialObjectCastFailureTest.kt
@@ -1,0 +1,39 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.api.DependencyProvider
+import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
+import com.episode6.hackit.mockspresso.basic.plugin.injectBySimpleConfig
+import com.episode6.hackit.mockspresso.createNew
+import com.episode6.hackit.mockspresso.exception.BrokenSpecialObjectMakerException
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
+import com.episode6.hackit.mockspresso.reflect.DependencyKey
+import org.fest.assertions.api.Assertions.assertThat
+import org.fest.assertions.api.Fail.fail
+import org.junit.Test
+
+class SpecialObjectCastFailureTest {
+
+  @Test fun testBadSpecialObjectMaker() {
+    val mockspresso = BuildMockspresso.with()
+        .injectBySimpleConfig()
+        .mockByMockito()
+        .specialObjectMaker(BadSpecialObjectMaker())
+        .build()
+
+    try {
+      mockspresso.createNew<TestClass>()
+      fail("exception expected")
+    } catch (e: BrokenSpecialObjectMakerException) {
+      assertThat(e.message).isEqualTo("Special object maker returned an invalid object. SpecialObjectMaker: com.episode6.hackit.mockspresso.mockito.integration.BadSpecialObjectMaker, expected: DependencyKey{typeToken=int}, but object returned type: java.lang.String, value: fail")
+    }
+
+  }
+}
+
+class BadSpecialObjectMaker : SpecialObjectMaker {
+  override fun canMakeObject(key: DependencyKey<*>): Boolean = true
+  override fun makeObject(dependencyProvider: DependencyProvider, key: DependencyKey<*>): Any? = "fail"
+}
+
+class TestClass(val intDep: Int)


### PR DESCRIPTION
Validate the output of SpecialObjectMakers as the objects are made. Turns out the casting was not throwing exceptions, but we can use reflection to make the same assertion.