### PR TITLE
[Fix] Catch ClassCastExceptions for injection config constructors

### DIFF
--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/exception/Exceptions.kt
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/exception/Exceptions.kt
@@ -1,5 +1,6 @@
 package com.episode6.hackit.mockspresso.exception
 
+import com.episode6.hackit.mockspresso.api.InjectionConfig
 import com.episode6.hackit.mockspresso.api.SpecialObjectMaker
 import com.episode6.hackit.mockspresso.reflect.DependencyKey
 import com.episode6.hackit.mockspresso.reflect.TypeToken
@@ -24,3 +25,6 @@ class RepeatedDependencyDefinedException(key: DependencyKey<*>) : VerifyError("D
  */
 class BrokenSpecialObjectMakerException(maker: SpecialObjectMaker, key: DependencyKey<*>, value: Any?) : IllegalArgumentException(
     "Special object maker returned an invalid object. SpecialObjectMaker: ${maker.javaClass.name}, expected: $key, but object returned type: ${value?.javaClass?.name}, value: $value")
+
+class BrokenInjectionConfigException(config: InjectionConfig, token: TypeToken<*>, value: Any?) : IllegalArgumentException(
+    "InjectionConfig returned an invalid constructor. InjectionConfig: ${config.javaClass.name}, expected: $token, but constructor resulted in object of type: ${value?.javaClass?.name}, value: $value")

--- a/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/RealObjectMaker.java
+++ b/mockspresso-core/src/main/java/com/episode6/hackit/mockspresso/internal/RealObjectMaker.java
@@ -2,6 +2,7 @@ package com.episode6.hackit.mockspresso.internal;
 
 import com.episode6.hackit.mockspresso.api.DependencyProvider;
 import com.episode6.hackit.mockspresso.api.InjectionConfig;
+import com.episode6.hackit.mockspresso.exception.BrokenInjectionConfigException;
 import com.episode6.hackit.mockspresso.exception.NoValidConstructorException;
 import com.episode6.hackit.mockspresso.reflect.DependencyKey;
 import com.episode6.hackit.mockspresso.reflect.ReflectUtil;
@@ -64,6 +65,9 @@ class RealObjectMaker  {
     }
 
     T instance = constructor.newInstance(paramValues);
+    if (!typeToken.getRawType().isAssignableFrom(instance.getClass())) {
+      throw new BrokenInjectionConfigException(mInjectionConfig, typeToken, instance);
+    }
     injectObject(dependencyProvider, instance, typeToken);
     return instance;
   }

--- a/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/ConstructorCastFailureTest.kt
+++ b/mockspresso-mockito/src/test/java/com/episode6/hackit/mockspresso/mockito/integration/ConstructorCastFailureTest.kt
@@ -1,0 +1,38 @@
+package com.episode6.hackit.mockspresso.mockito.integration
+
+import com.episode6.hackit.mockspresso.BuildMockspresso
+import com.episode6.hackit.mockspresso.api.InjectionConfig
+import com.episode6.hackit.mockspresso.createNew
+import com.episode6.hackit.mockspresso.exception.BrokenInjectionConfigException
+import com.episode6.hackit.mockspresso.mockito.mockByMockito
+import com.episode6.hackit.mockspresso.reflect.TypeToken
+import org.fest.assertions.api.Assertions.assertThat
+import org.fest.assertions.api.Assertions.fail
+import org.junit.Test
+import java.lang.reflect.Constructor
+
+class ConstructorCastFailureTest {
+  @Test fun testBadInjectionConfig() {
+    val mockspresso = BuildMockspresso.with()
+        .injector(BadInjectConfig())
+        .mockByMockito()
+        .build()
+
+    try {
+      mockspresso.createNew<ConstructorTestClass>()
+      fail("expected an exception")
+    } catch (e: BrokenInjectionConfigException) {
+      assertThat(e.message).startsWith("InjectionConfig returned an invalid constructor. InjectionConfig: com.episode6.hackit.mockspresso.mockito.integration.BadInjectConfig, expected: com.episode6.hackit.mockspresso.mockito.integration.ConstructorTestClass, but constructor resulted in object of type: com.episode6.hackit.mockspresso.mockito.integration.OtherConstructorTestClass, value: com.episode6.hackit.mockspresso.mockito.integration.OtherConstructorTestClass@")
+    }
+  }
+}
+
+class ConstructorTestClass()
+class OtherConstructorTestClass()
+
+class BadInjectConfig : InjectionConfig {
+  override fun provideInjectableFieldAnnotations(): List<Class<out Annotation>> = emptyList()
+  override fun provideInjectableMethodAnnotations(): List<Class<out Annotation>> = emptyList()
+  override fun chooseConstructor(typeToken: TypeToken<*>): Constructor<out Any>? = OtherConstructorTestClass::class.java.declaredConstructors.first()
+
+}


### PR DESCRIPTION
If an InjectionConfig doesn't return constructors for the correct class it can be very difficult to track down the issue. Here we update our RealObjectMaker to assert the created objects are assignable to the TypeToken we've created them from.